### PR TITLE
Use a local per-thread allocator context 

### DIFF
--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -17,8 +17,10 @@
 #pragma once
 
 template <typename KeyT, typename ValueT>
-void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::
-    buildBulk(KeyT* d_key, ValueT* d_value, uint32_t num_keys) {
+void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::buildBulk(
+    KeyT* d_key,
+    ValueT* d_value,
+    uint32_t num_keys) {
   const uint32_t num_blocks = (num_keys + BLOCKSIZE_ - 1) / BLOCKSIZE_;
   // calling the kernel for bulk build:
   CHECK_CUDA_ERROR(cudaSetDevice(device_idx_));
@@ -27,26 +29,31 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::
 }
 
 template <typename KeyT, typename ValueT>
-void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::
-    searchIndividual(KeyT* d_query, ValueT* d_result, uint32_t num_queries) {
+void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::searchIndividual(
+    KeyT* d_query,
+    ValueT* d_result,
+    uint32_t num_queries) {
   CHECK_CUDA_ERROR(cudaSetDevice(device_idx_));
   const uint32_t num_blocks = (num_queries + BLOCKSIZE_ - 1) / BLOCKSIZE_;
-  search_table<KeyT, ValueT><<<num_blocks, BLOCKSIZE_>>>(
-      d_query, d_result, num_queries, gpu_context_);
+  search_table<KeyT, ValueT>
+      <<<num_blocks, BLOCKSIZE_>>>(d_query, d_result, num_queries, gpu_context_);
 }
 
 template <typename KeyT, typename ValueT>
-void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::
-    searchBulk(KeyT* d_query, ValueT* d_result, uint32_t num_queries) {
+void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::searchBulk(
+    KeyT* d_query,
+    ValueT* d_result,
+    uint32_t num_queries) {
   CHECK_CUDA_ERROR(cudaSetDevice(device_idx_));
   const uint32_t num_blocks = (num_queries + BLOCKSIZE_ - 1) / BLOCKSIZE_;
-  search_table_bulk<KeyT, ValueT><<<num_blocks, BLOCKSIZE_>>>(
-      d_query, d_result, num_queries, gpu_context_);
+  search_table_bulk<KeyT, ValueT>
+      <<<num_blocks, BLOCKSIZE_>>>(d_query, d_result, num_queries, gpu_context_);
 }
 
 template <typename KeyT, typename ValueT>
-void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::
-    deleteIndividual(KeyT* d_key, uint32_t num_keys) {
+void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::deleteIndividual(
+    KeyT* d_key,
+    uint32_t num_keys) {
   CHECK_CUDA_ERROR(cudaSetDevice(device_idx_));
   const uint32_t num_blocks = (num_keys + BLOCKSIZE_ - 1) / BLOCKSIZE_;
   delete_table_keys<KeyT, ValueT>
@@ -55,8 +62,10 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::
 
 // perform a batch of (a mixture of) updates/searches
 template <typename KeyT, typename ValueT>
-void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::
-    batchedOperation(KeyT* d_key, ValueT* d_result, uint32_t num_ops) {
+void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::batchedOperation(
+    KeyT* d_key,
+    ValueT* d_result,
+    uint32_t num_ops) {
   CHECK_CUDA_ERROR(cudaSetDevice(device_idx_));
   const uint32_t num_blocks = (num_ops + BLOCKSIZE_ - 1) / BLOCKSIZE_;
   batched_operations<KeyT, ValueT>
@@ -64,40 +73,34 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::
 }
 
 template <typename KeyT, typename ValueT>
-std::string
-GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::
-    to_string() {
+std::string GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::to_string() {
   std::string result;
   result += " ==== GpuSlabHash: \n";
   result += "\t Running on device \t\t " + std::to_string(device_idx_) + "\n";
-  result +=
-      "\t SlabHashType:     \t\t " + gpu_context_.getSlabHashTypeName() + "\n";
+  result += "\t SlabHashType:     \t\t " + gpu_context_.getSlabHashTypeName() + "\n";
   result += "\t Number of buckets:\t\t " + std::to_string(num_buckets_) + "\n";
-  result +=
-      "\t d_table_ address: \t\t " +
-      std::to_string(reinterpret_cast<uint64_t>(static_cast<void*>(d_table_))) +
-      "\n";
+  result += "\t d_table_ address: \t\t " +
+            std::to_string(reinterpret_cast<uint64_t>(static_cast<void*>(d_table_))) +
+            "\n";
   result += "\t hash function = \t\t (" + std::to_string(hf_.x) + ", " +
             std::to_string(hf_.y) + ")\n";
   return result;
 }
 
 template <typename KeyT, typename ValueT>
-double GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::
-    computeLoadFactor(int flag = 0) {
+double GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::computeLoadFactor(
+    int flag = 0) {
   uint32_t* h_bucket_count = new uint32_t[num_buckets_];
   uint32_t* d_bucket_count;
-  CHECK_CUDA_ERROR(
-      cudaMalloc((void**)&d_bucket_count, sizeof(uint32_t) * num_buckets_));
-  CHECK_CUDA_ERROR(
-      cudaMemset(d_bucket_count, 0, sizeof(uint32_t) * num_buckets_));
+  CHECK_CUDA_ERROR(cudaMalloc((void**)&d_bucket_count, sizeof(uint32_t) * num_buckets_));
+  CHECK_CUDA_ERROR(cudaMemset(d_bucket_count, 0, sizeof(uint32_t) * num_buckets_));
 
   const auto& dynamic_alloc = gpu_context_.getAllocatorContext();
   const uint32_t num_super_blocks = dynamic_alloc.num_super_blocks_;
   uint32_t* h_count_super_blocks = new uint32_t[num_super_blocks];
   uint32_t* d_count_super_blocks;
-  CHECK_CUDA_ERROR(cudaMalloc((void**)&d_count_super_blocks,
-                              sizeof(uint32_t) * num_super_blocks));
+  CHECK_CUDA_ERROR(
+      cudaMalloc((void**)&d_count_super_blocks, sizeof(uint32_t) * num_super_blocks));
   CHECK_CUDA_ERROR(
       cudaMemset(d_count_super_blocks, 0, sizeof(uint32_t) * num_super_blocks));
   //---------------------------------
@@ -106,7 +109,8 @@ double GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::
   const uint32_t num_blocks = (num_buckets_ * 32 + blocksize - 1) / blocksize;
   bucket_count_kernel<KeyT, ValueT>
       <<<num_blocks, blocksize>>>(gpu_context_, d_bucket_count, num_buckets_);
-  CHECK_CUDA_ERROR(cudaMemcpy(h_bucket_count, d_bucket_count,
+  CHECK_CUDA_ERROR(cudaMemcpy(h_bucket_count,
+                              d_bucket_count,
                               sizeof(uint32_t) * num_buckets_,
                               cudaMemcpyDeviceToHost));
 
@@ -115,7 +119,8 @@ double GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::
     total_elements_stored += h_bucket_count[i];
 
   if (flag) {
-    printf("## Total elements stored: %d (%lu bytes).\n", total_elements_stored,
+    printf("## Total elements stored: %d (%lu bytes).\n",
+           total_elements_stored,
            total_elements_stored * (sizeof(KeyT) + sizeof(ValueT)));
   }
 
@@ -125,7 +130,8 @@ double GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::
   compute_stats_allocators<<<num_cuda_blocks, blocksize>>>(d_count_super_blocks,
                                                            gpu_context_);
 
-  CHECK_CUDA_ERROR(cudaMemcpy(h_count_super_blocks, d_count_super_blocks,
+  CHECK_CUDA_ERROR(cudaMemcpy(h_count_super_blocks,
+                              d_count_super_blocks,
                               sizeof(uint32_t) * num_super_blocks,
                               cudaMemcpyDeviceToHost));
 
@@ -133,9 +139,10 @@ double GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::
   if (flag == 1) {
     int total_allocated = 0;
     for (int i = 0; i < num_super_blocks; i++) {
-      printf(
-          "(%d: %d -- %f) \t", i, h_count_super_blocks[i],
-          double(h_count_super_blocks[i]) / double(1024 * num_mem_units / 32));
+      printf("(%d: %d -- %f) \t",
+             i,
+             h_count_super_blocks[i],
+             double(h_count_super_blocks[i]) / double(1024 * num_mem_units / 32));
       if (i % 4 == 3)
         printf("\n");
       total_allocated += h_count_super_blocks[i];
@@ -148,9 +155,8 @@ double GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::
   for (int i = 0; i < num_super_blocks; i++)
     total_mem_units += h_count_super_blocks[i];
 
-  double load_factor =
-      double(total_elements_stored * (sizeof(KeyT) + sizeof(ValueT))) /
-      double(total_mem_units * WARP_WIDTH_ * sizeof(uint32_t));
+  double load_factor = double(total_elements_stored * (sizeof(KeyT) + sizeof(ValueT))) /
+                       double(total_mem_units * WARP_WIDTH_ * sizeof(uint32_t));
 
   if (d_count_super_blocks)
     CHECK_ERROR(cudaFree(d_count_super_blocks));

--- a/src/concurrent_map/device/build.cuh
+++ b/src/concurrent_map/device/build.cuh
@@ -31,8 +31,8 @@ __global__ void build_table_kernel(
     return;
   }
 
-  // initializing the memory allocator on each warp:
-  slab_hash.getAllocatorContext().initAllocator(tid, laneId);
+  AllocatorContextT local_allocator_ctx(slab_hash.getAllocatorContext());
+  local_allocator_ctx.initAllocator(tid, laneId);
 
   KeyT myKey = 0;
   ValueT myValue = 0;
@@ -45,6 +45,6 @@ __global__ void build_table_kernel(
     myBucket = slab_hash.computeBucket(myKey);
     to_insert = true;
   }
-
-  slab_hash.insertPair(to_insert, laneId, myKey, myValue, myBucket);
+  
+  slab_hash.insertPair(to_insert, laneId, myKey, myValue, myBucket, local_allocator_ctx);
 }

--- a/src/concurrent_map/device/concurrent_kernel.cuh
+++ b/src/concurrent_map/device/concurrent_kernel.cuh
@@ -29,7 +29,8 @@ __global__ void batched_operations(
     return;
 
   // initializing the memory allocator on each warp:
-  slab_hash.getAllocatorContext().initAllocator(tid, laneId);
+  AllocatorContextT local_allocator_ctx(slab_hash.getAllocatorContext());
+  local_allocator_ctx.initAllocator(tid, laneId);
 
   uint32_t myOperation = 0;
   uint32_t myKey = 0;
@@ -50,7 +51,7 @@ __global__ void batched_operations(
   bool to_search = (myOperation == 3) ? true : false;
 
   // first insertions:
-  slab_hash.insertPair(to_insert, laneId, myKey, myValue, myBucket);
+  slab_hash.insertPair(to_insert, laneId, myKey, myValue, myBucket, local_allocator_ctx);
 
   // second deletions:
   slab_hash.deleteKey(to_delete, laneId, myKey, myBucket);

--- a/src/concurrent_map/device/concurrent_kernel.cuh
+++ b/src/concurrent_map/device/concurrent_kernel.cuh
@@ -41,7 +41,7 @@ __global__ void batched_operations(
     myKey = myOperation & 0x3FFFFFFF;
     myBucket = slab_hash.computeBucket(myKey);
     myOperation = myOperation >> 30;
-    // todo: should be changed to a more general case 
+    // todo: should be changed to a more general case
     myValue = myKey;  // for the sake of this benchmark
   }
 

--- a/src/concurrent_map/device/delete_kernel.cuh
+++ b/src/concurrent_map/device/delete_kernel.cuh
@@ -28,9 +28,6 @@ __global__ void delete_table_keys(
     return;
   }
 
-  // initializing the memory allocator:
-  slab_hash.getAllocatorContext().initAllocator(tid, laneId);
-
   KeyT myKey = 0;
   uint32_t myBucket = 0;
   bool to_delete = false;

--- a/src/concurrent_map/device/misc_kernels.cuh
+++ b/src/concurrent_map/device/misc_kernels.cuh
@@ -70,15 +70,13 @@ __global__ void compute_stats_allocators(
     GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap> slab_hash) {
   uint32_t tid = threadIdx.x + blockIdx.x * blockDim.x;
 
-  int num_bitmaps =
-      slab_hash.getAllocatorContext().NUM_MEM_BLOCKS_PER_SUPER_BLOCK_ * 32;
+  int num_bitmaps = slab_hash.getAllocatorContext().NUM_MEM_BLOCKS_PER_SUPER_BLOCK_ * 32;
   if (tid >= num_bitmaps) {
     return;
   }
 
   for (int i = 0; i < slab_hash.getAllocatorContext().num_super_blocks_; i++) {
-    uint32_t read_bitmap =
-        *(slab_hash.getAllocatorContext().getPointerForBitmap(i, tid));
+    uint32_t read_bitmap = *(slab_hash.getAllocatorContext().getPointerForBitmap(i, tid));
     atomicAdd(&d_count_super_block[i], __popc(read_bitmap));
   }
 }

--- a/src/concurrent_map/device/search_kernel.cuh
+++ b/src/concurrent_map/device/search_kernel.cuh
@@ -30,9 +30,6 @@ __global__ void search_table(
     return;
   }
 
-  // initializing the memory allocator on each warp:
-  slab_hash.getAllocatorContext().initAllocator(tid, laneId);
-
   KeyT myQuery = 0;
   ValueT myResult = static_cast<ValueT>(SEARCH_NOT_FOUND);
   uint32_t myBucket = 0;
@@ -64,9 +61,6 @@ __global__ void search_table_bulk(
   if ((tid - laneId) >= num_queries) {
     return;
   }
-
-  // initializing the memory allocator on each warp:
-  slab_hash.getAllocatorContext().initAllocator(tid, laneId);
 
   KeyT myQuery = 0;
   ValueT myResult = static_cast<ValueT>(SEARCH_NOT_FOUND);

--- a/src/concurrent_map/warp/insert.cuh
+++ b/src/concurrent_map/warp/insert.cuh
@@ -28,7 +28,8 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::insertPair(
     const uint32_t& laneId,
     const KeyT& myKey,
     const ValueT& myValue,
-    const uint32_t bucket_id) {
+    const uint32_t bucket_id, 
+  AllocatorContextT& local_allocator_ctx) {
   using SlabHashT = ConcurrentMapT<KeyT, ValueT>;
   uint32_t work_queue = 0;
   uint32_t last_work_queue = 0;
@@ -52,7 +53,7 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::insertPair(
       uint32_t next_ptr = __shfl_sync(0xFFFFFFFF, src_unit_data, 31, 32);
       if (next_ptr == SlabHashT::EMPTY_INDEX_POINTER) {
         // allocate a new node:
-        uint32_t new_node_ptr = allocateSlab(laneId);
+        uint32_t new_node_ptr = allocateSlab(local_allocator_ctx, laneId);
 
         // TODO: experiment if it's better to use lane 0 instead
         if (laneId == 31) {

--- a/src/concurrent_map/warp/insert.cuh
+++ b/src/concurrent_map/warp/insert.cuh
@@ -36,9 +36,8 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::insertPair(
 
   while ((work_queue = __ballot_sync(0xFFFFFFFF, to_be_inserted))) {
     // to know whether it is a base node, or a regular node
-    next = (last_work_queue != work_queue)
-               ? SlabHashT::A_INDEX_POINTER
-               : next;  // a successfull insertion in the warp
+    next = (last_work_queue != work_queue) ? SlabHashT::A_INDEX_POINTER
+                                           : next;  // a successfull insertion in the warp
     uint32_t src_lane = __ffs(work_queue) - 1;
     uint32_t src_bucket = __shfl_sync(0xFFFFFFFF, bucket_id, src_lane, 32);
 
@@ -61,8 +60,8 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::insertPair(
                                   ? getPointerFromBucket(src_bucket, 31)
                                   : getPointerFromSlab(next, 31);
 
-          uint32_t temp = atomicCAS(
-              (unsigned int*)p, SlabHashT::EMPTY_INDEX_POINTER, new_node_ptr);
+          uint32_t temp =
+              atomicCAS((unsigned int*)p, SlabHashT::EMPTY_INDEX_POINTER, new_node_ptr);
           // check whether it was successful, and
           // free the allocated memory otherwise
           if (temp != SlabHashT::EMPTY_INDEX_POINTER) {
@@ -80,7 +79,8 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::insertPair(
                                 : getPointerFromSlab(next, dest_lane);
 
         old_key_value_pair =
-            atomicCAS((unsigned long long int*)p, EMPTY_PAIR_64,
+            atomicCAS((unsigned long long int*)p,
+                      EMPTY_PAIR_64,
                       ((uint64_t)(*reinterpret_cast<const uint32_t*>(
                            reinterpret_cast<const unsigned char*>(&myValue)))
                        << 32) |

--- a/src/concurrent_set/cset_class.cuh
+++ b/src/concurrent_set/cset_class.cuh
@@ -28,9 +28,24 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet> {
   static constexpr uint32_t PRIME_DIVISOR_ = 4294967291u;
   static constexpr uint32_t WARP_WIDTH_ = 32;
 
-  GpuSlabHashContext() : num_buckets_(0), hash_x_(0), hash_y_(0), d_table_(nullptr) {
-    // a single slab on a ConcurrentMap should be 128 bytes
+#pragma hd_warning_disable
+  __device__ __host__ GpuSlabHashContext()
+      : num_buckets_(0), hash_x_(0), hash_y_(0), d_table_(nullptr) {
+    // a single slab on a ConcurrentSet should be 128 bytes
   }
+
+#pragma hd_warning_disable
+  __host__ __device__ GpuSlabHashContext(
+      GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>& rhs) {
+    num_buckets_ = rhs.getNumBuckets();
+    hash_x_ = rhs.getHashX();
+    hash_y_ = rhs.getHashY();
+    d_table_ = rhs.getDeviceTablePointer();
+    global_allocator_ctx_ = rhs.getAllocatorContext();
+  }
+
+#pragma hd_warning_disable
+  __host__ __device__ ~GpuSlabHashContext() {}
 
   static size_t getSlabUnitSize() {
     return sizeof(typename ConcurrentSetT<KeyT>::SlabTypeT);
@@ -47,11 +62,11 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet> {
     hash_x_ = hash_x;
     hash_y_ = hash_y;
     d_table_ = reinterpret_cast<typename ConcurrentSetT<KeyT>::SlabTypeT*>(d_table);
-    dynamic_allocator_ = *allocator_ctx;
+    global_allocator_ctx_ = *allocator_ctx;
   }
 
   __device__ __host__ __forceinline__ AllocatorContextT& getAllocatorContext() {
-    return dynamic_allocator_;
+    return global_allocator_ctx_;
   }
 
   __device__ __host__ __forceinline__ typename ConcurrentSetT<KeyT>::SlabTypeT*
@@ -60,6 +75,8 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet> {
   }
 
   __device__ __host__ __forceinline__ uint32_t getNumBuckets() { return num_buckets_; }
+  __device__ __host__ __forceinline__ uint32_t getHashX() { return hash_x_; }
+  __device__ __host__ __forceinline__ uint32_t getHashY() { return hash_y_; }
 
   __device__ __host__ __forceinline__ uint32_t computeBucket(const KeyT& key) const {
     return (((hash_x_ ^ key) + hash_y_) % PRIME_DIVISOR_) % num_buckets_;
@@ -70,7 +87,8 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet> {
   __device__ __forceinline__ void insertKey(bool& to_be_inserted,
                                             const uint32_t& laneId,
                                             const KeyT& myKey,
-                                            const uint32_t bucket_id);
+                                            const uint32_t bucket_id,
+                                            AllocatorContextT& local_allocator_context);
 
   // threads in a warp cooeparte with each other to search for keys
   // if found, it returns the true, else false
@@ -89,7 +107,7 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet> {
   __device__ __forceinline__ uint32_t* getPointerFromSlab(
       const SlabAddressT& slab_address,
       const uint32_t laneId) {
-    return dynamic_allocator_.getPointerFromSlab(slab_address, laneId);
+    return global_allocator_ctx_.getPointerFromSlab(slab_address, laneId);
   }
 
   __device__ __forceinline__ uint32_t* getPointerFromBucket(const uint32_t bucket_id,
@@ -102,12 +120,17 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet> {
   // this function should be operated in a warp-wide fashion
   // TODO: add required asserts to make sure this is true in tests/debugs
   __device__ __forceinline__ SlabAllocAddressT allocateSlab(const uint32_t& laneId) {
-    return dynamic_allocator_.warpAllocate(laneId);
+    return global_allocator_ctx_.warpAllocate(laneId);
+  }
+
+  __device__ __forceinline__ SlabAllocAddressT
+  allocateSlab(AllocatorContextT& local_allocator_ctx, const uint32_t& laneId) {
+    return local_allocator_ctx.warpAllocate(laneId);
   }
 
   // a thread-wide function to free the slab that was just allocated
   __device__ __forceinline__ void freeSlab(const SlabAllocAddressT slab_ptr) {
-    dynamic_allocator_.freeUntouched(slab_ptr);
+    global_allocator_ctx_.freeUntouched(slab_ptr);
   }
 
   // === members:
@@ -116,7 +139,7 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet> {
   uint32_t hash_y_;
   typename ConcurrentSetT<KeyT>::SlabTypeT* d_table_;
   // a copy of dynamic allocator's context to be used on the GPU
-  AllocatorContextT dynamic_allocator_;
+  AllocatorContextT global_allocator_ctx_;
 };
 
 /*
@@ -164,6 +187,9 @@ class GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentSet> {
       , dynamic_allocator_(dynamic_allocator)
       , device_idx_(device_idx) {
     assert(dynamic_allocator && "No proper dynamic allocator attached to the slab hash.");
+    assert(sizeof(typename ConcurrentSetT<KeyT>::SlabTypeT) ==
+               (WARP_WIDTH_ * sizeof(uint32_t)) &&
+           "A single slab on a ConcurrentMap should be 128 bytes");
     int32_t devCount = 0;
     CHECK_CUDA_ERROR(cudaGetDeviceCount(&devCount));
     assert(device_idx_ < devCount);

--- a/src/concurrent_set/cset_helper_kernels.cuh
+++ b/src/concurrent_set/cset_helper_kernels.cuh
@@ -29,7 +29,8 @@ __global__ void build_table_kernel(
   }
 
   // initializing the memory allocator on each warp:
-  slab_hash.getAllocatorContext().initAllocator(tid, laneId);
+  AllocatorContextT local_allocator_ctx(slab_hash.getAllocatorContext());
+  local_allocator_ctx.initAllocator(tid, laneId);
 
   KeyT myKey = 0;
   uint32_t myBucket = 0;
@@ -41,7 +42,7 @@ __global__ void build_table_kernel(
     to_insert = true;
   }
 
-  slab_hash.insertKey(to_insert, laneId, myKey, myBucket);
+  slab_hash.insertKey(to_insert, laneId, myKey, myBucket, local_allocator_ctx);
 }
 
 //=== Individual search kernel:
@@ -57,9 +58,6 @@ __global__ void search_table(
   if ((tid - laneId) >= num_queries) {
     return;
   }
-
-  // initializing the memory allocator on each warp:
-  slab_hash.getAllocatorContext().initAllocator(tid, laneId);
 
   KeyT myQuery = 0;
   uint32_t myBucket = 0;

--- a/src/concurrent_set/cset_helper_kernels.cuh
+++ b/src/concurrent_set/cset_helper_kernels.cuh
@@ -74,7 +74,7 @@ __global__ void search_table(
 
   // writing back the results:
   if (tid < num_queries) {
-    d_results[tid] =  myResult ? myQuery : SEARCH_NOT_FOUND;
+    d_results[tid] = myResult ? myQuery : SEARCH_NOT_FOUND;
   }
 }
 };  // namespace cset

--- a/src/concurrent_set/cset_implementation.cuh
+++ b/src/concurrent_set/cset_implementation.cuh
@@ -17,8 +17,10 @@
 #pragma once
 
 template <typename KeyT, typename ValueT>
-void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>::
-    buildBulk(KeyT* d_key, ValueT* d_value, uint32_t num_keys) {
+void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>::buildBulk(
+    KeyT* d_key,
+    ValueT* d_value,
+    uint32_t num_keys) {
   const uint32_t num_blocks = (num_keys + BLOCKSIZE_ - 1) / BLOCKSIZE_;
   // calling the kernel for bulk build:
   CHECK_CUDA_ERROR(cudaSetDevice(device_idx_));
@@ -27,28 +29,26 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>::
 }
 
 template <typename KeyT, typename ValueT>
-void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>::
-    searchIndividual(KeyT* d_query, ValueT* d_result, uint32_t num_queries) {
+void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>::searchIndividual(
+    KeyT* d_query,
+    ValueT* d_result,
+    uint32_t num_queries) {
   CHECK_CUDA_ERROR(cudaSetDevice(device_idx_));
   const uint32_t num_blocks = (num_queries + BLOCKSIZE_ - 1) / BLOCKSIZE_;
-  cset::search_table<KeyT><<<num_blocks, BLOCKSIZE_>>>(
-      d_query, d_result, num_queries, gpu_context_);
+  cset::search_table<KeyT>
+      <<<num_blocks, BLOCKSIZE_>>>(d_query, d_result, num_queries, gpu_context_);
 }
 
 template <typename KeyT, typename ValueT>
-std::string
-GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>::
-    to_string() {
+std::string GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>::to_string() {
   std::string result;
   result += " ==== GpuSlabHash: \n";
   result += "\t Running on device \t\t " + std::to_string(device_idx_) + "\n";
-  result +=
-      "\t SlabHashType:     \t\t " + gpu_context_.getSlabHashTypeName() + "\n";
+  result += "\t SlabHashType:     \t\t " + gpu_context_.getSlabHashTypeName() + "\n";
   result += "\t Number of buckets:\t\t " + std::to_string(num_buckets_) + "\n";
-  result +=
-      "\t d_table_ address: \t\t " +
-      std::to_string(reinterpret_cast<uint64_t>(static_cast<void*>(d_table_))) +
-      "\n";
+  result += "\t d_table_ address: \t\t " +
+            std::to_string(reinterpret_cast<uint64_t>(static_cast<void*>(d_table_))) +
+            "\n";
   result += "\t hash function = \t\t (" + std::to_string(hf_.x) + ", " +
             std::to_string(hf_.y) + ")\n";
   return result;

--- a/src/concurrent_set/cset_warp_operations.cuh
+++ b/src/concurrent_set/cset_warp_operations.cuh
@@ -22,7 +22,8 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>::insertKey(
     bool& to_be_inserted,
     const uint32_t& laneId,
     const KeyT& myKey,
-    const uint32_t bucket_id) {
+    const uint32_t bucket_id, 
+    AllocatorContextT& local_allocator_ctx) {
   using SlabHashT = ConcurrentSetT<KeyT>;
   uint32_t work_queue = 0;
   uint32_t last_work_queue = 0;
@@ -50,7 +51,7 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>::insertKey(
       uint32_t next_ptr = __shfl_sync(0xFFFFFFFF, src_unit_data, 31, 32);
       if (next_ptr == SlabHashT::EMPTY_INDEX_POINTER) {
         // allocate a new node:
-        uint32_t new_node_ptr = allocateSlab(laneId);
+        uint32_t new_node_ptr = allocateSlab(local_allocator_ctx, laneId);
 
         if (laneId == 31) {
           uint32_t* p = (next == SlabHashT::A_INDEX_POINTER)

--- a/src/concurrent_set/cset_warp_operations.cuh
+++ b/src/concurrent_set/cset_warp_operations.cuh
@@ -30,9 +30,8 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>::insertKey(
 
   while ((work_queue = __ballot_sync(0xFFFFFFFF, to_be_inserted))) {
     // to know whether it is a base node, or a regular node
-    next = (last_work_queue != work_queue)
-               ? SlabHashT::A_INDEX_POINTER
-               : next;  // a successfull insertion in the warp
+    next = (last_work_queue != work_queue) ? SlabHashT::A_INDEX_POINTER
+                                           : next;  // a successfull insertion in the warp
     uint32_t src_lane = __ffs(work_queue) - 1;
     KeyT src_key = __shfl_sync(0xFFFFFFFF, myKey, src_lane, 32);
     uint32_t src_bucket = __shfl_sync(0xFFFFFFFF, bucket_id, src_lane, 32);
@@ -44,9 +43,8 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>::insertKey(
     uint32_t old_key = 0;
 
     // looking for the same key (if it exists), or an empty spot:
-    int32_t dest_lane =
-        SlabHash_NS::findKeyOrEmptyPerWarp<KeyT, ConcurrentSetT<KeyT>>(
-            src_key, src_unit_data);
+    int32_t dest_lane = SlabHash_NS::findKeyOrEmptyPerWarp<KeyT, ConcurrentSetT<KeyT>>(
+        src_key, src_unit_data);
 
     if (dest_lane == -1) {  // key not found and/or no empty slot available:
       uint32_t next_ptr = __shfl_sync(0xFFFFFFFF, src_unit_data, 31, 32);
@@ -59,8 +57,8 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>::insertKey(
                             ? getPointerFromBucket(src_bucket, 31)
                             : getPointerFromSlab(next, 31);
 
-          uint32_t temp = atomicCAS(
-              (unsigned int*)p, SlabHashT::EMPTY_INDEX_POINTER, new_node_ptr);
+          uint32_t temp =
+              atomicCAS((unsigned int*)p, SlabHashT::EMPTY_INDEX_POINTER, new_node_ptr);
           // check whether it was successful, and
           // free the allocated memory otherwise
           if (temp != SlabHashT::EMPTY_INDEX_POINTER)
@@ -75,7 +73,8 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>::insertKey(
                                 ? getPointerFromBucket(src_bucket, dest_lane)
                                 : getPointerFromSlab(next, dest_lane);
 
-        old_key = atomicCAS((unsigned int*)p, EMPTY_KEY,
+        old_key = atomicCAS((unsigned int*)p,
+                            EMPTY_KEY,
                             *reinterpret_cast<const uint32_t*>(
                                 reinterpret_cast<const unsigned char*>(&myKey)));
         if ((old_key == EMPTY_KEY) || (old_key == src_key)) {
@@ -95,24 +94,22 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>::searchKey(
     const uint32_t& laneId,
     const KeyT& myKey,
     const uint32_t bucket_id) {
-	bool myResult = false;
-	using SlabHashT = ConcurrentSetT<KeyT>;
+  bool myResult = false;
+  using SlabHashT = ConcurrentSetT<KeyT>;
   uint32_t work_queue = 0;
   uint32_t last_work_queue = work_queue;
   uint32_t next = SlabHashT::A_INDEX_POINTER;
 
   while ((work_queue = __ballot_sync(0xFFFFFFFF, to_be_searched))) {
-    next = (last_work_queue != work_queue)
-               ? SlabHashT::A_INDEX_POINTER
-               : next;  // a successfull insertion in the warp
+    next = (last_work_queue != work_queue) ? SlabHashT::A_INDEX_POINTER
+                                           : next;  // a successfull insertion in the warp
     uint32_t src_lane = __ffs(work_queue) - 1;
     uint32_t src_bucket = __shfl_sync(0xFFFFFFFF, bucket_id, src_lane, 32);
     KeyT wanted_key = __shfl_sync(0xFFFFFFFF, myKey, src_lane, 32);
 
-    const uint32_t src_unit_data =
-        (next == SlabHashT::A_INDEX_POINTER)
-            ? *getPointerFromBucket(src_bucket, laneId)
-            : *getPointerFromSlab(next, laneId);
+    const uint32_t src_unit_data = (next == SlabHashT::A_INDEX_POINTER)
+                                       ? *getPointerFromBucket(src_bucket, laneId)
+                                       : *getPointerFromSlab(next, laneId);
 
     int32_t found_lane = SlabHash_NS::findKeyPerWarp<KeyT, ConcurrentSetT<KeyT>>(
         wanted_key, src_unit_data);

--- a/src/gpu_hash_table.cuh
+++ b/src/gpu_hash_table.cuh
@@ -21,9 +21,7 @@
  * This class acts as a helper class to simplify simulations around different
  * kinds of slab hash implementations
  */
-template <typename KeyT,
-          typename ValueT,
-          SlabHashTypeT SlabHashT>
+template <typename KeyT, typename ValueT, SlabHashTypeT SlabHashT>
 class gpu_hash_table {
  private:
   uint32_t max_keys_;
@@ -49,19 +47,19 @@ class gpu_hash_table {
 
   gpu_hash_table(uint32_t max_keys,
                  uint32_t num_buckets,
-                 const uint32_t device_idx, 
+                 const uint32_t device_idx,
                  const int64_t seed,
                  const bool req_values = true,
                  const bool identity_hash = false,
                  const bool verbose = false)
-      : max_keys_(max_keys),
-        num_buckets_(num_buckets),
-        seed_(seed),
-        req_values_(req_values),
-        slab_hash_(nullptr),
-        identity_hash_(identity_hash),
-        dynamic_allocator_(nullptr),
-        device_idx_(device_idx) {
+      : max_keys_(max_keys)
+      , num_buckets_(num_buckets)
+      , seed_(seed)
+      , req_values_(req_values)
+      , slab_hash_(nullptr)
+      , identity_hash_(identity_hash)
+      , dynamic_allocator_(nullptr)
+      , device_idx_(device_idx) {
     int32_t devCount = 0;
     CHECK_CUDA_ERROR(cudaGetDeviceCount(&devCount));
     assert(device_idx_ < devCount);
@@ -71,12 +69,10 @@ class gpu_hash_table {
     // allocating key, value arrays:
     CHECK_CUDA_ERROR(cudaMalloc((void**)&d_key_, sizeof(KeyT) * max_keys_));
     if (req_values_) {
-      CHECK_CUDA_ERROR(
-          cudaMalloc((void**)&d_value_, sizeof(ValueT) * max_keys_));
+      CHECK_CUDA_ERROR(cudaMalloc((void**)&d_value_, sizeof(ValueT) * max_keys_));
     }
     CHECK_CUDA_ERROR(cudaMalloc((void**)&d_query_, sizeof(KeyT) * max_keys_));
-    CHECK_CUDA_ERROR(
-        cudaMalloc((void**)&d_result_, sizeof(ValueT) * max_keys_));
+    CHECK_CUDA_ERROR(cudaMalloc((void**)&d_result_, sizeof(ValueT) * max_keys_));
 
     // allocate an initialize the allocator:
     dynamic_allocator_ = new DynamicAllocatorT();
@@ -108,11 +104,11 @@ class gpu_hash_table {
   float hash_build(KeyT* h_key, ValueT* h_value, uint32_t num_keys) {
     // moving key-values to the device:
     CHECK_CUDA_ERROR(cudaSetDevice(device_idx_));
-    CHECK_CUDA_ERROR(cudaMemcpy(d_key_, h_key, sizeof(KeyT) * num_keys,
-                                cudaMemcpyHostToDevice));
+    CHECK_CUDA_ERROR(
+        cudaMemcpy(d_key_, h_key, sizeof(KeyT) * num_keys, cudaMemcpyHostToDevice));
     if (req_values_) {
-      CHECK_CUDA_ERROR(cudaMemcpy(d_value_, h_value, sizeof(ValueT) * num_keys,
-                                  cudaMemcpyHostToDevice));
+      CHECK_CUDA_ERROR(cudaMemcpy(
+          d_value_, h_value, sizeof(ValueT) * num_keys, cudaMemcpyHostToDevice));
     }
 
     float temp_time = 0.0f;
@@ -137,8 +133,8 @@ class gpu_hash_table {
 
   float hash_search(KeyT* h_query, ValueT* h_result, uint32_t num_queries) {
     CHECK_CUDA_ERROR(cudaSetDevice(device_idx_));
-    CHECK_CUDA_ERROR(cudaMemcpy(d_query_, h_query, sizeof(KeyT) * num_queries,
-                                cudaMemcpyHostToDevice));
+    CHECK_CUDA_ERROR(cudaMemcpy(
+        d_query_, h_query, sizeof(KeyT) * num_queries, cudaMemcpyHostToDevice));
     CHECK_CUDA_ERROR(cudaMemset(d_result_, 0xFF, sizeof(ValueT) * num_queries));
 
     float temp_time = 0.0f;
@@ -159,18 +155,15 @@ class gpu_hash_table {
     cudaEventDestroy(start);
     cudaEventDestroy(stop);
 
-    CHECK_CUDA_ERROR(cudaMemcpy(h_result, d_result_,
-                                sizeof(ValueT) * num_queries,
-                                cudaMemcpyDeviceToHost));
+    CHECK_CUDA_ERROR(cudaMemcpy(
+        h_result, d_result_, sizeof(ValueT) * num_queries, cudaMemcpyDeviceToHost));
     cudaDeviceSynchronize();
     return temp_time;
   }
-  float hash_search_bulk(KeyT* h_query,
-                         ValueT* h_result,
-                         uint32_t num_queries) {
+  float hash_search_bulk(KeyT* h_query, ValueT* h_result, uint32_t num_queries) {
     CHECK_CUDA_ERROR(cudaSetDevice(device_idx_));
-    CHECK_CUDA_ERROR(cudaMemcpy(d_query_, h_query, sizeof(KeyT) * num_queries,
-                                cudaMemcpyHostToDevice));
+    CHECK_CUDA_ERROR(cudaMemcpy(
+        d_query_, h_query, sizeof(KeyT) * num_queries, cudaMemcpyHostToDevice));
     CHECK_CUDA_ERROR(cudaMemset(d_result_, 0xFF, sizeof(ValueT) * num_queries));
 
     float temp_time = 0.0f;
@@ -191,17 +184,16 @@ class gpu_hash_table {
     cudaEventDestroy(start);
     cudaEventDestroy(stop);
 
-    CHECK_CUDA_ERROR(cudaMemcpy(h_result, d_result_,
-                                sizeof(ValueT) * num_queries,
-                                cudaMemcpyDeviceToHost));
+    CHECK_CUDA_ERROR(cudaMemcpy(
+        h_result, d_result_, sizeof(ValueT) * num_queries, cudaMemcpyDeviceToHost));
     cudaDeviceSynchronize();
     return temp_time;
   }
 
   float hash_delete(KeyT* h_key, uint32_t num_keys) {
     CHECK_CUDA_ERROR(cudaSetDevice(device_idx_));
-    CHECK_CUDA_ERROR(cudaMemcpy(d_key_, h_key, sizeof(KeyT) * num_keys,
-                                cudaMemcpyHostToDevice));
+    CHECK_CUDA_ERROR(
+        cudaMemcpy(d_key_, h_key, sizeof(KeyT) * num_keys, cudaMemcpyHostToDevice));
 
     float temp_time = 0.0f;
 
@@ -227,11 +219,12 @@ class gpu_hash_table {
                            uint32_t batch_size,
                            uint32_t batch_id) {
     CHECK_CUDA_ERROR(cudaSetDevice(device_idx_));
-    CHECK_CUDA_ERROR(cudaMemcpy(d_key_ + batch_id * batch_size, h_batch_op,
+    CHECK_CUDA_ERROR(cudaMemcpy(d_key_ + batch_id * batch_size,
+                                h_batch_op,
                                 sizeof(uint32_t) * batch_size,
                                 cudaMemcpyHostToDevice));
-    CHECK_CUDA_ERROR(cudaMemset(d_result_ + batch_id * batch_size, 0xFF,
-                                sizeof(uint32_t) * batch_size));
+    CHECK_CUDA_ERROR(cudaMemset(
+        d_result_ + batch_id * batch_size, 0xFF, sizeof(uint32_t) * batch_size));
 
     float temp_time = 0.0f;
 
@@ -240,8 +233,7 @@ class gpu_hash_table {
     cudaEventCreate(&stop);
 
     cudaEventRecord(start, 0);
-    slab_hash_->batchedOperation(d_key_ + batch_id * batch_size, d_result_,
-                               batch_size);
+    slab_hash_->batchedOperation(d_key_ + batch_id * batch_size, d_result_, batch_size);
     cudaEventRecord(stop, 0);
     cudaEventSynchronize(stop);
     cudaEventElapsedTime(&temp_time, start, stop);
@@ -249,14 +241,13 @@ class gpu_hash_table {
     cudaEventDestroy(start);
     cudaEventDestroy(stop);
 
-    CHECK_ERROR(cudaMemcpy(
-        h_results + batch_id * batch_size, d_result_ + batch_id * batch_size,
-        sizeof(uint32_t) * batch_size, cudaMemcpyDeviceToHost));
+    CHECK_ERROR(cudaMemcpy(h_results + batch_id * batch_size,
+                           d_result_ + batch_id * batch_size,
+                           sizeof(uint32_t) * batch_size,
+                           cudaMemcpyDeviceToHost));
     cudaDeviceSynchronize();
     return temp_time;
   }
 
-  float measureLoadFactor(int flag = 0) {
-    return slab_hash_->computeLoadFactor(flag);
-  }
+  float measureLoadFactor(int flag = 0) { return slab_hash_->computeLoadFactor(flag); }
 };

--- a/src/gpu_hash_table.cuh
+++ b/src/gpu_hash_table.cuh
@@ -101,6 +101,7 @@ class gpu_hash_table {
     delete (slab_hash_);
   }
 
+  std::string to_string() { return slab_hash_->to_string(); }
   float hash_build(KeyT* h_key, ValueT* h_value, uint32_t num_keys) {
     // moving key-values to the device:
     CHECK_CUDA_ERROR(cudaSetDevice(device_idx_));

--- a/src/slab_hash.cuh
+++ b/src/slab_hash.cuh
@@ -40,12 +40,12 @@
 
 // helper kernels:
 #include "concurrent_map/device/build.cuh"
+#include "concurrent_map/device/concurrent_kernel.cuh"
 #include "concurrent_map/device/delete_kernel.cuh"
 #include "concurrent_map/device/misc_kernels.cuh"
 #include "concurrent_map/device/search_kernel.cuh"
-#include "concurrent_map/device/concurrent_kernel.cuh"
 #include "concurrent_set/cset_helper_kernels.cuh"
 
 // implementations:
 #include "concurrent_map/cmap_implementation.cuh"
-#include "concurrent_set/cset_implementation.cuh" 
+#include "concurrent_set/cset_implementation.cuh"

--- a/src/slab_hash_global.cuh
+++ b/src/slab_hash_global.cuh
@@ -18,14 +18,13 @@
 
 #include "slab_alloc.cuh"
 
-#define CHECK_CUDA_ERROR(call)                                \
-  do {                                                        \
-    cudaError_t err = call;                                   \
-    if (err != cudaSuccess) {                                 \
-      printf("CUDA error at %s %d: %s\n", __FILE__, __LINE__, \
-             cudaGetErrorString(err));                        \
-      exit(EXIT_FAILURE);                                     \
-    }                                                         \
+#define CHECK_CUDA_ERROR(call)                                                          \
+  do {                                                                                  \
+    cudaError_t err = call;                                                             \
+    if (err != cudaSuccess) {                                                           \
+      printf("CUDA error at %s %d: %s\n", __FILE__, __LINE__, cudaGetErrorString(err)); \
+      exit(EXIT_FAILURE);                                                               \
+    }                                                                                   \
   } while (0)
 
 // internal parameters for slab hash device functions:
@@ -97,7 +96,6 @@ class ConcurrentMapT {
 template <typename KeyT>
 class ConcurrentSetT {
  public:
-
   // fixed parameters for the data structure
   static constexpr uint32_t A_INDEX_POINTER = 0xFFFFFFFE;
   static constexpr uint32_t EMPTY_INDEX_POINTER = 0xFFFFFFFF;
@@ -120,9 +118,7 @@ class PhaseConcurrentMapT {
 };
 
 // the main class to be specialized for different types of hash tables
-template <typename KeyT,
-          typename ValueT,
-          SlabHashTypeT SlabHashT>
+template <typename KeyT, typename ValueT, SlabHashTypeT SlabHashT>
 class GpuSlabHash;
 
 template <typename KeyT, typename ValueT, SlabHashTypeT SlabHashT>
@@ -140,10 +136,9 @@ using DynamicAllocatorT = SlabAllocLight<slab_alloc_par::log_num_mem_blocks,
                                          slab_alloc_par::num_super_blocks,
                                          slab_alloc_par::num_replicas>;
 
-using AllocatorContextT =
-    SlabAllocLightContext<slab_alloc_par::log_num_mem_blocks,
-                          slab_alloc_par::num_super_blocks,
-                          slab_alloc_par::num_replicas>;
+using AllocatorContextT = SlabAllocLightContext<slab_alloc_par::log_num_mem_blocks,
+                                                slab_alloc_par::num_super_blocks,
+                                                slab_alloc_par::num_replicas>;
 
 using SlabAddressT = uint32_t;
 using BucketAddressT = SlabAddressT;

--- a/src/slab_hash_helper_methods.cuh
+++ b/src/slab_hash_helper_methods.cuh
@@ -22,26 +22,24 @@ namespace SlabHash_NS {
  * if found, otherwise returns -1
  */
 template <typename KeyT, class SlabHashT>
-__device__ __forceinline__ int32_t
-findKeyOrEmptyPerWarp(const KeyT& src_key, const uint32_t read_data_chunk) {
-  uint32_t isEmpty =
-      (__ballot_sync(0xFFFFFFFF, (read_data_chunk == EMPTY_KEY) ||
-                                     (read_data_chunk == src_key)));
+__device__ __forceinline__ int32_t findKeyOrEmptyPerWarp(const KeyT& src_key,
+                                                         const uint32_t read_data_chunk) {
+  uint32_t isEmpty = (__ballot_sync(
+      0xFFFFFFFF, (read_data_chunk == EMPTY_KEY) || (read_data_chunk == src_key)));
   return __ffs(isEmpty & SlabHashT::REGULAR_NODE_KEY_MASK) - 1;
 }
 
 // search for just the key
 template <typename KeyT, class SlabHashT>
-__device__ __forceinline__ int32_t
-findKeyPerWarp(const KeyT& src_key, const uint32_t read_data_chunk) {
+__device__ __forceinline__ int32_t findKeyPerWarp(const KeyT& src_key,
+                                                  const uint32_t read_data_chunk) {
   uint32_t isEmpty = __ballot_sync(0xFFFFFFFF, (read_data_chunk == src_key));
   return __ffs(isEmpty & SlabHashT::REGULAR_NODE_KEY_MASK) - 1;
 }
 
 // search for an empty spot
 template <typename KeyT, class SlabHashT>
-__device__ __forceinline__ int32_t
-findEmptyPerWarp(const uint32_t read_data_chunk) {
+__device__ __forceinline__ int32_t findEmptyPerWarp(const uint32_t read_data_chunk) {
   uint32_t isEmpty = __ballot_sync(0xFFFFFFFF, (read_data_chunk == EMPTY_KEY));
   return __ffs(isEmpty & SlabHashT::REGULAR_NODE_KEY_MASK) - 1;
 }

--- a/src/slab_iterator.cuh
+++ b/src/slab_iterator.cuh
@@ -34,14 +34,13 @@ class SlabIterator {
   SlabAddressT cur_slab_address_;
   // initialize the iterator with the first bucket's pointer address of the slab
   // hash
-  __host__ __device__ SlabIterator(
-      GpuSlabHashContext<KeyT, KeyT, SlabHashTypeT::ConcurrentSet>& slab_hash)
-      : slab_hash_(slab_hash),
-        cur_ptr_(reinterpret_cast<KeyT*>(slab_hash_.getDeviceTablePointer())),
-        cur_size_(slab_hash_.getNumBuckets() * SlabHashT::BASE_UNIT_SIZE),
-        cur_bucket_(0),
-        cur_slab_address_(
-            *slab_hash.getPointerFromBucket(0, SlabHashT::NEXT_PTR_LANE)) {}
+  __host__ __device__
+  SlabIterator(GpuSlabHashContext<KeyT, KeyT, SlabHashTypeT::ConcurrentSet>& slab_hash)
+      : slab_hash_(slab_hash)
+      , cur_ptr_(reinterpret_cast<KeyT*>(slab_hash_.getDeviceTablePointer()))
+      , cur_size_(slab_hash_.getNumBuckets() * SlabHashT::BASE_UNIT_SIZE)
+      , cur_bucket_(0)
+      , cur_slab_address_(*slab_hash.getPointerFromBucket(0, SlabHashT::NEXT_PTR_LANE)) {}
 
   __device__ __forceinline__ KeyT* getPointer() const { return cur_ptr_; }
   __device__ __forceinline__ uint32_t getSize() const { return cur_size_; }
@@ -59,13 +58,13 @@ class SlabIterator {
       if (cur_bucket_ == slab_hash_.getNumBuckets()) {
         return false;
       }
-      cur_slab_address_ = *slab_hash_.getPointerFromBucket(
-          cur_bucket_, SlabHashT::NEXT_PTR_LANE);
+      cur_slab_address_ =
+          *slab_hash_.getPointerFromBucket(cur_bucket_, SlabHashT::NEXT_PTR_LANE);
     }
 
     cur_ptr_ = slab_hash_.getPointerFromSlab(cur_slab_address_, 0);
-    cur_slab_address_ = *slab_hash_.getPointerFromSlab(cur_slab_address_,
-                                                      SlabHashT::NEXT_PTR_LANE);
+    cur_slab_address_ =
+        *slab_hash_.getPointerFromSlab(cur_slab_address_, SlabHashT::NEXT_PTR_LANE);
     cur_size_ = SlabHashT::BASE_UNIT_SIZE;
     return true;
   }


### PR DESCRIPTION
This PR solves the issue https://github.com/owensgroup/SlabHash/issues/8

The major change is that we should build a local allocator context per thread so that each thread has its own version of resident_bitmap, allocated_result, etc. Previously all threads were using a global allocator context.