### PR TITLE
 Updating computeLoadFactor with slabs counting

### DIFF
--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -111,80 +111,55 @@ std::string GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::to_string()
 template <typename KeyT, typename ValueT>
 double GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::computeLoadFactor(
     int flag = 0) {
-  uint32_t* h_bucket_count = new uint32_t[num_buckets_];
-  uint32_t* d_bucket_count;
-  CHECK_CUDA_ERROR(cudaMalloc((void**)&d_bucket_count, sizeof(uint32_t) * num_buckets_));
-  CHECK_CUDA_ERROR(cudaMemset(d_bucket_count, 0, sizeof(uint32_t) * num_buckets_));
+  uint32_t* h_bucket_pairs_count = new uint32_t[num_buckets_];
+  uint32_t* d_bucket_pairs_count;
+  CHECK_CUDA_ERROR(cudaMalloc((void**)&d_bucket_pairs_count, sizeof(uint32_t) * num_buckets_));
+  CHECK_CUDA_ERROR(cudaMemset(d_bucket_pairs_count, 0, sizeof(uint32_t) * num_buckets_));
 
-  const auto& dynamic_alloc = gpu_context_.getAllocatorContext();
-  const uint32_t num_super_blocks = dynamic_alloc.num_super_blocks_;
-  uint32_t* h_count_super_blocks = new uint32_t[num_super_blocks];
-  uint32_t* d_count_super_blocks;
-  CHECK_CUDA_ERROR(
-      cudaMalloc((void**)&d_count_super_blocks, sizeof(uint32_t) * num_super_blocks));
-  CHECK_CUDA_ERROR(
-      cudaMemset(d_count_super_blocks, 0, sizeof(uint32_t) * num_super_blocks));
+  uint32_t* h_bucket_slabs_count = new uint32_t[num_buckets_];
+  uint32_t* d_bucket_slabs_count;
+  CHECK_CUDA_ERROR(cudaMalloc((void**)&d_bucket_slabs_count, sizeof(uint32_t) * num_buckets_));
+  CHECK_CUDA_ERROR(cudaMemset(d_bucket_slabs_count, 0, sizeof(uint32_t) * num_buckets_));
+
   //---------------------------------
   // counting the number of inserted elements:
   const uint32_t blocksize = 128;
   const uint32_t num_blocks = (num_buckets_ * 32 + blocksize - 1) / blocksize;
   bucket_count_kernel<KeyT, ValueT>
-      <<<num_blocks, blocksize>>>(gpu_context_, d_bucket_count, num_buckets_);
-  CHECK_CUDA_ERROR(cudaMemcpy(h_bucket_count,
-                              d_bucket_count,
+      <<<num_blocks, blocksize>>>(gpu_context_, d_bucket_pairs_count, d_bucket_slabs_count, num_buckets_);
+  CHECK_CUDA_ERROR(cudaMemcpy(h_bucket_pairs_count,
+                              d_bucket_pairs_count,
                               sizeof(uint32_t) * num_buckets_,
                               cudaMemcpyDeviceToHost));
-
+  CHECK_CUDA_ERROR(cudaMemcpy(h_bucket_slabs_count,
+                              d_bucket_slabs_count,
+                              sizeof(uint32_t) * num_buckets_,
+                              cudaMemcpyDeviceToHost));
   int total_elements_stored = 0;
-  for (int i = 0; i < num_buckets_; i++)
-    total_elements_stored += h_bucket_count[i];
-
+  int total_slabs_used = 0;
+  for (int i = 0; i < num_buckets_; i++){
+    total_elements_stored += h_bucket_pairs_count[i];
+    total_slabs_used += h_bucket_slabs_count[i];
+  } 
   if (flag) {
     printf("## Total elements stored: %d (%lu bytes).\n",
            total_elements_stored,
            total_elements_stored * (sizeof(KeyT) + sizeof(ValueT)));
+    printf("## Total buckets used: %d.\n",
+           total_slabs_used);
   }
 
-  // counting total number of allocated memory units:
-  int num_mem_units = dynamic_alloc.NUM_MEM_BLOCKS_PER_SUPER_BLOCK_ * 32;
-  int num_cuda_blocks = (num_mem_units + blocksize - 1) / blocksize;
-  compute_stats_allocators<<<num_cuda_blocks, blocksize>>>(d_count_super_blocks,
-                                                           gpu_context_);
 
-  CHECK_CUDA_ERROR(cudaMemcpy(h_count_super_blocks,
-                              d_count_super_blocks,
-                              sizeof(uint32_t) * num_super_blocks,
-                              cudaMemcpyDeviceToHost));
-
-  // printing stats per super block:
-  if (flag == 1) {
-    int total_allocated = 0;
-    for (int i = 0; i < num_super_blocks; i++) {
-      printf("(%d: %d -- %f) \t",
-             i,
-             h_count_super_blocks[i],
-             double(h_count_super_blocks[i]) / double(1024 * num_mem_units / 32));
-      if (i % 4 == 3)
-        printf("\n");
-      total_allocated += h_count_super_blocks[i];
-    }
-    printf("\n");
-    printf("Total number of allocated memory units: %d\n", total_allocated);
-  }
   // computing load factor
-  int total_mem_units = num_buckets_;
-  for (int i = 0; i < num_super_blocks; i++)
-    total_mem_units += h_count_super_blocks[i];
-
   double load_factor = double(total_elements_stored * (sizeof(KeyT) + sizeof(ValueT))) /
-                       double(total_mem_units * WARP_WIDTH_ * sizeof(uint32_t));
+                       double(total_slabs_used * WARP_WIDTH_ * sizeof(uint32_t));
 
-  if (d_count_super_blocks)
-    CHECK_ERROR(cudaFree(d_count_super_blocks));
-  if (d_bucket_count)
-    CHECK_ERROR(cudaFree(d_bucket_count));
-  delete[] h_bucket_count;
-  delete[] h_count_super_blocks;
+  if (d_bucket_pairs_count)
+    CHECK_ERROR(cudaFree(d_bucket_pairs_count));
+  if (d_bucket_slabs_count)
+    CHECK_ERROR(cudaFree(d_bucket_slabs_count));
+  delete[] h_bucket_pairs_count;
+  delete[] h_bucket_slabs_count;
 
   return load_factor;
 }

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -147,7 +147,7 @@ double GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::computeLoadFacto
     printf("## Total elements stored: %d (%lu bytes).\n",
            total_elements_stored,
            total_elements_stored * (sizeof(KeyT) + sizeof(ValueT)));
-    printf("## Total buckets used: %d.\n", total_slabs_used);
+    printf("## Total number of slabs used: %d.\n", total_slabs_used);
   }
 
   // computing load factor

--- a/src/concurrent_map/device/misc_kernels.cuh
+++ b/src/concurrent_map/device/misc_kernels.cuh
@@ -17,8 +17,9 @@
 #pragma once
 
 /*
- * This kernel can be used to compute total number of elements within each
- * bucket. The final results per bucket is stored in d_count_result array
+ * This kernel can be used to compute the total number of elements and the total number of
+ * slabs per bucket. The final results per bucket is stored in d_pairs_count_result and
+ * d_slabs_count_result arrays respectively
  */
 template <typename KeyT, typename ValueT>
 __global__ void bucket_count_kernel(

--- a/src/concurrent_map/device/misc_kernels.cuh
+++ b/src/concurrent_map/device/misc_kernels.cuh
@@ -46,16 +46,16 @@ __global__ void bucket_count_kernel(
   uint32_t src_unit_data = *slab_hash.getPointerFromBucket(wid, laneId);
 
   pairs_count += __popc(__ballot_sync(0xFFFFFFFF, src_unit_data != EMPTY_KEY) &
-                  SlabHashT::REGULAR_NODE_KEY_MASK);
+                        SlabHashT::REGULAR_NODE_KEY_MASK);
   uint32_t next = __shfl_sync(0xFFFFFFFF, src_unit_data, 31, 32);
 
   while (next != SlabHashT::EMPTY_INDEX_POINTER) {
     // counting pairs
     src_unit_data = *slab_hash.getPointerFromSlab(next, laneId);
     pairs_count += __popc(__ballot_sync(0xFFFFFFFF, src_unit_data != EMPTY_KEY) &
-                    SlabHashT::REGULAR_NODE_KEY_MASK);
+                          SlabHashT::REGULAR_NODE_KEY_MASK);
     next = __shfl_sync(0xFFFFFFFF, src_unit_data, 31, 32);
-    //counting slabs
+    // counting slabs
     slabs_count++;
   }
   // writing back the results:

--- a/src/concurrent_map/device/misc_kernels.cuh
+++ b/src/concurrent_map/device/misc_kernels.cuh
@@ -23,7 +23,8 @@
 template <typename KeyT, typename ValueT>
 __global__ void bucket_count_kernel(
     GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap> slab_hash,
-    uint32_t* d_count_result,
+    uint32_t* d_pairs_count_result,
+    uint32_t* d_slabs_count_result,
     uint32_t num_buckets) {
   using SlabHashT = ConcurrentMapT<KeyT, ValueT>;
   // global warp ID
@@ -39,44 +40,27 @@ __global__ void bucket_count_kernel(
   // initializing the memory allocator on each warp:
   slab_hash.getAllocatorContext().initAllocator(tid, laneId);
 
-  uint32_t count = 0;
+  uint32_t pairs_count = 0;
+  uint32_t slabs_count = 1;
 
   uint32_t src_unit_data = *slab_hash.getPointerFromBucket(wid, laneId);
 
-  count += __popc(__ballot_sync(0xFFFFFFFF, src_unit_data != EMPTY_KEY) &
+  pairs_count += __popc(__ballot_sync(0xFFFFFFFF, src_unit_data != EMPTY_KEY) &
                   SlabHashT::REGULAR_NODE_KEY_MASK);
   uint32_t next = __shfl_sync(0xFFFFFFFF, src_unit_data, 31, 32);
 
   while (next != SlabHashT::EMPTY_INDEX_POINTER) {
+    // counting pairs
     src_unit_data = *slab_hash.getPointerFromSlab(next, laneId);
-    count += __popc(__ballot_sync(0xFFFFFFFF, src_unit_data != EMPTY_KEY) &
+    pairs_count += __popc(__ballot_sync(0xFFFFFFFF, src_unit_data != EMPTY_KEY) &
                     SlabHashT::REGULAR_NODE_KEY_MASK);
     next = __shfl_sync(0xFFFFFFFF, src_unit_data, 31, 32);
+    //counting slabs
+    slabs_count++;
   }
   // writing back the results:
   if (laneId == 0) {
-    d_count_result[wid] = count;
-  }
-}
-
-/*
- * This kernel goes through all allocated bitmaps for a slab_hash's allocator
- * and store number of allocated slabs.
- * TODO: this should be moved into allocator's codebase (violation of layers)
- */
-template <typename KeyT, typename ValueT>
-__global__ void compute_stats_allocators(
-    uint32_t* d_count_super_block,
-    GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap> slab_hash) {
-  uint32_t tid = threadIdx.x + blockIdx.x * blockDim.x;
-
-  int num_bitmaps = slab_hash.getAllocatorContext().NUM_MEM_BLOCKS_PER_SUPER_BLOCK_ * 32;
-  if (tid >= num_bitmaps) {
-    return;
-  }
-
-  for (int i = 0; i < slab_hash.getAllocatorContext().num_super_blocks_; i++) {
-    uint32_t read_bitmap = *(slab_hash.getAllocatorContext().getPointerForBitmap(i, tid));
-    atomicAdd(&d_count_super_block[i], __popc(read_bitmap));
+    d_pairs_count_result[wid] = pairs_count;
+    d_slabs_count_result[wid] = slabs_count;
   }
 }


### PR DESCRIPTION
Updating the `computeLoadFactor` function to count the number slabs without using bitmaps from the allocator. Will add the allocator memory usage function in a different PR. 