### PR TITLE
Unique insertion functions with boolean return value

### DIFF
--- a/src/concurrent_map/cmap_class.cuh
+++ b/src/concurrent_map/cmap_class.cuh
@@ -95,7 +95,7 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap> {
 
   // threads in a warp cooperate with each other to insert a unique key (and its value)
   // into the slab hash
-  __device__ __forceinline__ void insertPairUnique(
+  __device__ __forceinline__ bool insertPairUnique(
       bool& to_be_inserted,
       const uint32_t& laneId,
       const KeyT& myKey,

--- a/src/concurrent_map/warp/insert.cuh
+++ b/src/concurrent_map/warp/insert.cuh
@@ -175,7 +175,7 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::insertPairUnique
                          << 32) |
                             *reinterpret_cast<const uint32_t*>(
                                 reinterpret_cast<const unsigned char*>(&myKey)));
-          if (old_key_value_pair == EMPTY_PAIR_64){
+          if (old_key_value_pair == EMPTY_PAIR_64) {
             to_be_inserted = false;  // successful insertion
             new_insertion = true;
           }

--- a/src/concurrent_map/warp/insert.cuh
+++ b/src/concurrent_map/warp/insert.cuh
@@ -175,9 +175,10 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::insertPairUnique
                          << 32) |
                             *reinterpret_cast<const uint32_t*>(
                                 reinterpret_cast<const unsigned char*>(&myKey)));
-          if (old_key_value_pair == EMPTY_PAIR_64)
+          if (old_key_value_pair == EMPTY_PAIR_64){
             to_be_inserted = false;  // successful insertion
             new_insertion = true;
+          }
         }
       }
     }

--- a/src/concurrent_set/cset_class.cuh
+++ b/src/concurrent_set/cset_class.cuh
@@ -84,7 +84,7 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet> {
 
   // threads in a warp cooperate with each other to insert keys
   // into the slab hash set
-  __device__ __forceinline__ void insertKey(bool& to_be_inserted,
+  __device__ __forceinline__ bool insertKey(bool& to_be_inserted,
                                             const uint32_t& laneId,
                                             const KeyT& myKey,
                                             const uint32_t bucket_id,

--- a/src/concurrent_set/cset_warp_operations.cuh
+++ b/src/concurrent_set/cset_warp_operations.cuh
@@ -22,7 +22,7 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>::insertKey(
     bool& to_be_inserted,
     const uint32_t& laneId,
     const KeyT& myKey,
-    const uint32_t bucket_id, 
+    const uint32_t bucket_id,
     AllocatorContextT& local_allocator_ctx) {
   using SlabHashT = ConcurrentSetT<KeyT>;
   uint32_t work_queue = 0;

--- a/src/concurrent_set/cset_warp_operations.cuh
+++ b/src/concurrent_set/cset_warp_operations.cuh
@@ -17,7 +17,7 @@
 #pragma once
 
 template <typename KeyT, typename ValueT>
-__device__ __forceinline__ void
+__device__ __forceinline__ bool
 GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>::insertKey(
     bool& to_be_inserted,
     const uint32_t& laneId,
@@ -28,6 +28,7 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>::insertKey(
   uint32_t work_queue = 0;
   uint32_t last_work_queue = 0;
   uint32_t next = SlabHashT::A_INDEX_POINTER;
+  bool new_insertion = false;
 
   while ((work_queue = __ballot_sync(0xFFFFFFFF, to_be_inserted))) {
     // to know whether it is a base node, or a regular node
@@ -78,13 +79,15 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>::insertKey(
                             EMPTY_KEY,
                             *reinterpret_cast<const uint32_t*>(
                                 reinterpret_cast<const unsigned char*>(&myKey)));
-        if ((old_key == EMPTY_KEY) || (old_key == src_key)) {
+        new_insertion = (old_key == EMPTY_KEY);
+        if (new_insertion || (old_key == src_key)) {
           to_be_inserted = false;  // succesful insertion
         }
       }
     }
     last_work_queue = work_queue;
   }
+  return new_insertion;
 }
 
 // ========


### PR DESCRIPTION
Changed the unique insertion functions return value. Now the functions return `true` if a **new** key is inserted into the hash table. Useful for keeping track of how many unique keys exist inside the hash table.