### PR TITLE
Fix bug in cmap deleteKey

### DIFF
--- a/src/concurrent_map/warp/delete.cuh
+++ b/src/concurrent_map/warp/delete.cuh
@@ -58,7 +58,7 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::deleteKey(
       if (next_ptr == SlabHashT::EMPTY_INDEX_POINTER) {
         // not found:
         if (laneId == src_lane)
-          to_be_searched = false;
+          to_be_deleted = false;
       } else {
         next = next_ptr;
       }

--- a/src/concurrent_map/warp/delete.cuh
+++ b/src/concurrent_map/warp/delete.cuh
@@ -57,7 +57,8 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::deleteKey(
       uint32_t next_ptr = __shfl_sync(0xFFFFFFFF, src_unit_data, 31, 32);
       if (next_ptr == SlabHashT::EMPTY_INDEX_POINTER) {
         // not found:
-        to_be_deleted = false;
+        if (laneId == src_lane)
+          to_be_searched = false;
       } else {
         next = next_ptr;
       }


### PR DESCRIPTION
Concurrent map's `deleteKey` was missing an if statement before removing a key from the work queue.