### PR TITLE
Concurrent map deletion with bool return value

### DIFF
--- a/src/concurrent_map/cmap_class.cuh
+++ b/src/concurrent_map/cmap_class.cuh
@@ -129,7 +129,7 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap> {
 
   // all threads within a warp cooperate with each other to delete
   // keys
-  __device__ __forceinline__ void deleteKey(bool& to_be_deleted,
+  __device__ __forceinline__ bool deleteKey(bool& to_be_deleted,
                                             const uint32_t& laneId,
                                             const KeyT& myKey,
                                             const uint32_t bucket_id);

--- a/src/concurrent_map/warp/delete.cuh
+++ b/src/concurrent_map/warp/delete.cuh
@@ -71,7 +71,7 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::deleteKey(
                           : getPointerFromSlab(next, dest_lane);
 
         uint64_t old_pair = atomicExch((unsigned long long int*)p, EMPTY_PAIR_64);
-        uint32_t deleted_key = (old_pair & 0x00000000FFFFFFFFLL);
+        uint32_t deleted_key = static_cast<uint32_t>(old_pair);
         successful_deletion = deleted_key == src_key;
         to_be_deleted = false;
       }


### PR DESCRIPTION
Added a return value to check for successful key deletion in cmap to keep track of keys per hash table.