### PR TITLE
Dynamic growth of slab pool for concurrent_map

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "SlabAlloc"]
 	path = SlabAlloc
-	url = https://github.com/owensgroup/SlabAlloc
+	url = https://github.com/Nicolas-Iskos/SlabAlloc
 [submodule "ThirdParty/rapidjson"]
 	path = ThirdParty/rapidjson
 	url = https://github.com/Tencent/rapidjson

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "ThirdParty/googletest"]
 	path = ThirdParty/googletest
 	url = https://github.com/google/googletest
+[submodule "cub"]
+	path = cub
+	url = https://github.com/NVIDIA/cub.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package(CUDA 8.0 REQUIRED)
 option(CMAKE_VERBOSE_MAKEFILE ON)
 option(DGTEST,  "DGTEST"  ON)
 
-set(CUDA_NVCC_FLAGS -std=c++11)
+set(CUDA_NVCC_FLAGS -std=c++14)
 set (CMAKE_CXX_STANDARD 11)
 
 if (CUDA_VERBOSE_PTXAS)
@@ -83,6 +83,7 @@ if(SLABHASH_GENCODE_SM75)
 endif(SLABHASH_GENCODE_SM75)
 
 include_directories(SlabAlloc/src)
+include_directories(cub)
 include_directories(src src/concurrent)
 include_directories(ThirdParty/rapidjson/include)
 include_directories(ThirdParty/googletest/googletest)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SlabHash
-A warp-oriented dynamic hash table for GPUs
+A warp-oriented dynamic hash table for GPUs. 
+
+This fork of SlabHash is modified to allow for dynamic growth of the slab pool, allowing the slab hash to increase its total memory footprint as keys are inserted during run time.
 
 ## Publication:
 This library is based on the original slab hash paper, initially proposed in the following IPDPS'18 paper:

--- a/src/concurrent_map/cmap_class.cuh
+++ b/src/concurrent_map/cmap_class.cuh
@@ -102,7 +102,7 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap> {
 
   // threads in a warp cooperate with each other to insert key-value pairs
   // into the slab hash
-  __device__ __forceinline__ void insertPair(bool& mySuccess,
+  __device__ __forceinline__ void insertPair(/*bool& mySuccess,*/
                                              bool& to_be_inserted,
                                              const uint32_t& laneId,
                                              const KeyT& myKey,
@@ -113,7 +113,7 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap> {
   // threads in a warp cooperate with each other to insert a unique key (and its value)
   // into the slab hash
   __device__ __forceinline__ bool insertPairUnique(
-      bool& mySuccess,
+      /*bool& mySuccess,*/
       bool& to_be_inserted,
       const uint32_t& laneId,
       const KeyT& myKey,

--- a/src/concurrent_map/cmap_class.cuh
+++ b/src/concurrent_map/cmap_class.cuh
@@ -256,12 +256,14 @@ class GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap> {
 
     // creating a random number generator:
     if (!identity_hash) {
+      std::cout << "chicken" << std::endl;
       std::mt19937 rng(seed ? seed : time(0));
       hf_.x = rng() % PRIME_DIVISOR_;
       if (hf_.x < 1)
         hf_.x = 1;
       hf_.y = rng() % PRIME_DIVISOR_;
     } else {
+      std::cout << "cow" << std::endl;
       hf_ = {0u, 0u};
     }
 

--- a/src/concurrent_map/cmap_class.cuh
+++ b/src/concurrent_map/cmap_class.cuh
@@ -23,7 +23,8 @@
  * (i.e., d_table_)
  */
 template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
-class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks> {
+class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, 
+                         log_num_mem_blocks, num_super_blocks> {
  public:
   // fixed known parameters:
   static constexpr uint32_t PRIME_DIVISOR_ = 4294967291u;
@@ -36,7 +37,8 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem
 
 #pragma hd_warning_disable
   __host__ __device__ GpuSlabHashContext(
-      GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>& rhs) {
+      GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, 
+      log_num_mem_blocks, num_super_blocks>& rhs) {
     num_buckets_ = rhs.getNumBuckets();
     total_num_slabs_ = rhs.getTotalNumSlabs();
     total_num_keys_ = rhs.getTotalNumKeys();
@@ -61,7 +63,8 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem
                                const uint32_t hash_x,
                                const uint32_t hash_y,
                                int8_t* d_table,
-                               SlabAllocLightContext<log_num_mem_blocks, num_super_blocks, 1>* allocator_ctx) {
+                               SlabAllocLightContext<log_num_mem_blocks, 
+                               num_super_blocks, 1>* allocator_ctx) {
     num_buckets_ = num_buckets;
     hash_x_ = hash_x;
     hash_y_ = hash_y;
@@ -72,7 +75,8 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem
     total_num_keys_ = 0;
   }
 
-  __host__ void updateAllocatorContext(SlabAllocLightContext<log_num_mem_blocks, num_super_blocks, 1>* allocator_ctx) {
+  __host__ void updateAllocatorContext(SlabAllocLightContext<log_num_mem_blocks, 
+    num_super_blocks, 1>* allocator_ctx) {
     global_allocator_ctx_ = *allocator_ctx;
     total_num_slabs_ = num_buckets_ + global_allocator_ctx_.getNumSlabsInPool();
   }
@@ -81,7 +85,8 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem
     total_num_keys_ += keysAdded;
   }
 
-  __device__ __host__ __forceinline__ SlabAllocLightContext<log_num_mem_blocks, num_super_blocks, 1>& getAllocatorContext() {
+  __device__ __host__ __forceinline__ SlabAllocLightContext<log_num_mem_blocks, 
+    num_super_blocks, 1>& getAllocatorContext() {
     return global_allocator_ctx_;
   }
 
@@ -108,7 +113,8 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem
                                              const KeyT& myKey,
                                              const ValueT& myValue,
                                              const uint32_t bucket_id,
-                                             SlabAllocLightContext<log_num_mem_blocks, num_super_blocks, 1>& local_allocator_context);
+                                             SlabAllocLightContext<log_num_mem_blocks, 
+                                             num_super_blocks, 1>& local_allocator_context);
 
   // threads in a warp cooperate with each other to insert a unique key (and its value)
   // into the slab hash
@@ -172,7 +178,8 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem
   }
 
   __device__ __forceinline__ SlabAllocAddressT
-  allocateSlab(SlabAllocLightContext<log_num_mem_blocks, num_super_blocks, 1>& local_allocator_ctx, const uint32_t& laneId) {
+  allocateSlab(SlabAllocLightContext<log_num_mem_blocks, num_super_blocks, 1>& 
+    local_allocator_ctx, const uint32_t& laneId) {
     return local_allocator_ctx.warpAllocate(laneId);
   }
 
@@ -218,7 +225,8 @@ class GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks
 
   // slab hash context, contains everything that a GPU application needs to be
   // able to use this data structure
-  GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks> gpu_context_;
+  GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, 
+  log_num_mem_blocks, num_super_blocks> gpu_context_;
 
   // const pointer to an allocator that all instances of slab hash are going to
   // use. The allocator itself is not owned by this class
@@ -251,7 +259,8 @@ class GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks
     CHECK_CUDA_ERROR(cudaSetDevice(device_idx_));
 
     slab_unit_size_ =
-        GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::getSlabUnitSize();
+        GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, 
+        log_num_mem_blocks, num_super_blocks>::getSlabUnitSize();
 
     // allocating initial buckets:
     CHECK_CUDA_ERROR(cudaMalloc((void**)&d_table_, slab_unit_size_ * num_buckets_));

--- a/src/concurrent_map/cmap_class.cuh
+++ b/src/concurrent_map/cmap_class.cuh
@@ -222,21 +222,24 @@ class GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks
 
   // const pointer to an allocator that all instances of slab hash are going to
   // use. The allocator itself is not owned by this class
-  //DynamicAllocatorT* dynamic_allocator_;
   SlabAllocLight<log_num_mem_blocks, num_super_blocks, 1> *dynamic_allocator_;
   uint32_t device_idx_;
+
+  float thresh_lf_;
 
  public:
   GpuSlabHash(const uint32_t num_buckets,
               SlabAllocLight<log_num_mem_blocks, num_super_blocks, 1>* dynamic_allocator,
               uint32_t device_idx,
               const time_t seed = 0,
-              const bool identity_hash = false)
+              const bool identity_hash = false,
+              float thresh_lf = 0.60)
       : num_buckets_(num_buckets)
       , d_table_(nullptr)
       , slab_unit_size_(0)
       , dynamic_allocator_(dynamic_allocator)
-      , device_idx_(device_idx) {
+      , device_idx_(device_idx)
+      , thresh_lf_(thresh_lf) {
     assert(dynamic_allocator && "No proper dynamic allocator attached to the slab hash.");
     assert(sizeof(typename ConcurrentMapT<KeyT, ValueT>::SlabTypeT) ==
                (WARP_WIDTH_ * sizeof(uint32_t)) &&

--- a/src/concurrent_map/cmap_class.cuh
+++ b/src/concurrent_map/cmap_class.cuh
@@ -113,7 +113,7 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap> {
   // threads in a warp cooperate with each other to insert a unique key (and its value)
   // into the slab hash
   __device__ __forceinline__ bool insertPairUnique(
-      /*bool& mySuccess,*/
+      int& mySuccess,
       bool& to_be_inserted,
       const uint32_t& laneId,
       const KeyT& myKey,

--- a/src/concurrent_map/cmap_class.cuh
+++ b/src/concurrent_map/cmap_class.cuh
@@ -86,7 +86,8 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap> {
 
   // threads in a warp cooperate with each other to insert key-value pairs
   // into the slab hash
-  __device__ __forceinline__ void insertPair(bool& to_be_inserted,
+  __device__ __forceinline__ void insertPair(bool& mySuccess,
+                                             bool& to_be_inserted,
                                              const uint32_t& laneId,
                                              const KeyT& myKey,
                                              const ValueT& myValue,
@@ -245,9 +246,13 @@ class GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap> {
       hf_ = {0u, 0u};
     }
 
+    std::cout << "Initializing context params " << std::endl;
+
     // initializing the gpu_context_:
     gpu_context_.initParameters(
         num_buckets_, hf_.x, hf_.y, d_table_, dynamic_allocator_->getContextPtr());
+
+    std::cout << "Done initializing context params" << std::endl;
   }
 
   ~GpuSlabHash() {

--- a/src/concurrent_map/cmap_class.cuh
+++ b/src/concurrent_map/cmap_class.cuh
@@ -101,6 +101,7 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap> {
   // threads in a warp cooperate with each other to insert a unique key (and its value)
   // into the slab hash
   __device__ __forceinline__ bool insertPairUnique(
+      bool& mySuccess,
       bool& to_be_inserted,
       const uint32_t& laneId,
       const KeyT& myKey,

--- a/src/concurrent_map/cmap_class.cuh
+++ b/src/concurrent_map/cmap_class.cuh
@@ -256,14 +256,12 @@ class GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap> {
 
     // creating a random number generator:
     if (!identity_hash) {
-      std::cout << "chicken" << std::endl;
       std::mt19937 rng(seed ? seed : time(0));
       hf_.x = rng() % PRIME_DIVISOR_;
       if (hf_.x < 1)
         hf_.x = 1;
       hf_.y = rng() % PRIME_DIVISOR_;
     } else {
-      std::cout << "cow" << std::endl;
       hf_ = {0u, 0u};
     }
 

--- a/src/concurrent_map/cmap_class.cuh
+++ b/src/concurrent_map/cmap_class.cuh
@@ -250,13 +250,9 @@ class GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap> {
       hf_ = {0u, 0u};
     }
 
-    std::cout << "Initializing context params " << std::endl;
-
     // initializing the gpu_context_:
     gpu_context_.initParameters(
         num_buckets_, hf_.x, hf_.y, d_table_, dynamic_allocator_->getContextPtr());
-
-    std::cout << "Done initializing context params" << std::endl;
   }
 
   ~GpuSlabHash() {

--- a/src/concurrent_map/cmap_class.cuh
+++ b/src/concurrent_map/cmap_class.cuh
@@ -67,6 +67,10 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap> {
     global_allocator_ctx_ = *allocator_ctx;
   }
 
+  __host__ void updateAllocatorContext(AllocatorContextT* allocator_ctx) {
+    global_allocator_ctx_ = *allocator_ctx;
+  }
+
   __device__ __host__ __forceinline__ AllocatorContextT& getAllocatorContext() {
     return global_allocator_ctx_;
   }

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -36,7 +36,6 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::buildBulk(
   const uint32_t num_blocks = (num_keys + BLOCKSIZE_ - 1) / BLOCKSIZE_;
   CHECK_CUDA_ERROR(cudaSetDevice(device_idx_));
   while(h_retry) {
-    std::cout << "Calling build kernel" << std::endl;
     // calling the kernel for bulk build:
     build_table_kernel<KeyT, ValueT>
         <<<num_blocks, BLOCKSIZE_>>>(d_retry, d_success, d_key, d_value, num_keys, gpu_context_);
@@ -54,13 +53,10 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::buildBulk(
     std::cout << "numfalse " << num_false << std::endl;
     */
 
-    std::cout << "Evaluating need to resize" << std::endl;
     // resize the pool here if necessary
     if(h_retry) {
-      std::cout << "Resizing pool" << std::endl;
       dynamic_allocator_->growPool();
       gpu_context_.updateAllocatorContext(dynamic_allocator_->getContextPtr());
-      std::cout << "Done resizing pool" << std::endl;
     }
     CHECK_CUDA_ERROR(cudaMemset((void*)d_retry, 0x00, sizeof(int)));
   }

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -30,7 +30,7 @@ uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::checkForPreemp
   auto finalSlabLoadFactor = (float) (finalNumKeys) / maxElemCapacity;
   auto numResizes = 0;
 
-  if(finalSlabLoadFactor > 0.60) {
+  if(finalSlabLoadFactor > 0.70) {
     numResizes = 1;
   }
 

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -26,10 +26,11 @@ template <typename KeyT, typename ValueT>
 uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::checkForPreemptiveResize(uint32_t keysAdded) {
   auto numSlabs = gpu_context_.getTotalNumSlabs();
   std::cout << "numSlabs " << numSlabs << std::endl;
-  auto maxElemCapacity = numSlabs * 15;
+  
+  auto capacity = numSlabs * 16; // capacity in key-value size multiples
   auto finalNumKeys = gpu_context_.getTotalNumKeys() + keysAdded;
   std::cout << "finalNumKeys " << finalNumKeys << std::endl;
-  auto finalSlabLoadFactor = (float) (finalNumKeys) / maxElemCapacity;
+  auto finalSlabLoadFactor = (float) (finalNumKeys) / capacity;
   auto numResizes = 0;
 
   if(finalSlabLoadFactor > 0.70) {

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -32,7 +32,7 @@ uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::checkForPreemp
   auto finalSlabLoadFactor = (float) (finalNumKeys) / capacity;
   auto numResizes = 0;
 
-  if(finalSlabLoadFactor >= 0.60) {
+  if(finalSlabLoadFactor >= 0.90) {
     numResizes = 1;
   }
 

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -21,11 +21,47 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::buildBulk(
     KeyT* d_key,
     ValueT* d_value,
     uint32_t num_keys) {
+  
+  int h_retry = 1;
+  int *d_retry;
+  CHECK_CUDA_ERROR(cudaMalloc((void**)&d_retry, sizeof(int)));
+  CHECK_CUDA_ERROR(cudaMemset((void*)d_retry, 0x00, sizeof(int)));
+  bool* d_success;
+  CHECK_CUDA_ERROR(cudaMalloc((void**)&d_success, num_keys * sizeof(bool)));
+  CHECK_CUDA_ERROR(cudaMemset((void*)d_success, 0x00, num_keys * sizeof(bool)));
+
   const uint32_t num_blocks = (num_keys + BLOCKSIZE_ - 1) / BLOCKSIZE_;
-  // calling the kernel for bulk build:
-  CHECK_CUDA_ERROR(cudaSetDevice(device_idx_));
-  build_table_kernel<KeyT, ValueT>
-      <<<num_blocks, BLOCKSIZE_>>>(d_key, d_value, num_keys, gpu_context_);
+
+
+
+
+  bool *h_success = (bool*) malloc(num_keys * sizeof(bool));
+
+
+
+
+
+  while(h_retry) {
+    // calling the kernel for bulk build:
+    CHECK_CUDA_ERROR(cudaSetDevice(device_idx_));
+    build_table_kernel<KeyT, ValueT>
+        <<<num_blocks, BLOCKSIZE_>>>(d_retry, d_success, d_key, d_value, num_keys, gpu_context_);
+    CHECK_CUDA_ERROR(cudaMemcpy(&h_retry, d_retry, sizeof(int), cudaMemcpyDeviceToHost));
+
+    //
+    CHECK_CUDA_ERROR(cudaMemcpy(h_success, d_success, num_keys * sizeof(bool), cudaMemcpyDeviceToHost));
+    for(auto i = 0; i < num_keys; ++i) {
+      if(h_success[i] == false) {
+        std::cout << "Key " << i << " evaluated to false" << std::endl;
+        break;
+      }
+    }
+
+    std::cout << "Evaluating need to resize" << std::endl;
+    // resize the pool here if necessary
+
+    CHECK_CUDA_ERROR(cudaMemset((void*)d_retry, 0x00, sizeof(int)));
+  }
 }
 template <typename KeyT, typename ValueT>
 void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::buildBulkWithUniqueKeys(

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -28,11 +28,11 @@ uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::checkForPreemp
   
   auto capacity = numSlabs * 16; // capacity in key-value size multiples
   auto finalNumKeys = gpu_context_.getTotalNumKeys() + keysAdded;
-  std::cout << "finalNumKeys " << finalNumKeys << std::endl;
+  //std::cout << "finalNumKeys " << finalNumKeys << std::endl;
   auto finalSlabLoadFactor = (float) (finalNumKeys) / capacity;
   auto numResizes = 0;
 
-  if(finalSlabLoadFactor > 0.65) {
+  if(finalSlabLoadFactor > 0.60) {
     numResizes = 1;
   }
 
@@ -80,8 +80,6 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::buildBulkWithUniqu
   int *num_successes;
   CHECK_CUDA_ERROR(cudaMallocManaged(&num_successes, sizeof(int)));
   *num_successes = 0;
-
-  std::cout << "hashes" << gpu_context_.getHashX() << ", " << gpu_context_.getHashY() << std::endl;
 
   build_table_with_unique_keys_kernel<KeyT, ValueT>
       <<<num_blocks, BLOCKSIZE_>>>(num_successes, d_key, d_value, num_keys, gpu_context_);

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -25,11 +25,10 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::resize() {
 template <typename KeyT, typename ValueT>
 uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::checkForPreemptiveResize(uint32_t keysAdded) {
   auto numSlabs = gpu_context_.getTotalNumSlabs();
-  //std::cout << "numSlabs " << numSlabs << std::endl;
   
   auto capacity = numSlabs * 16; // capacity in key-value size multiples
   auto finalNumKeys = gpu_context_.getTotalNumKeys() + keysAdded;
-  //std::cout << "finalNumKeys " << finalNumKeys << std::endl;
+  std::cout << "finalNumKeys " << finalNumKeys << std::endl;
   auto finalSlabLoadFactor = (float) (finalNumKeys) / capacity;
   auto numResizes = 0;
 

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -29,11 +29,11 @@ uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::checkForPreemp
   
   auto capacity = numSlabs * 16; // capacity in key-value size multiples
   auto finalNumKeys = gpu_context_.getTotalNumKeys() + keysAdded;
-  //åstd::cout << "finalNumKeys " << finalNumKeys << std::endl;
+  //std::cout << "finalNumKeys " << finalNumKeys << std::endl;
   auto finalSlabLoadFactor = (float) (finalNumKeys) / capacity;
   auto numResizes = 0;
 
-  if(finalSlabLoadFactor > 0.60) {
+  if(finalSlabLoadFactor > 0.80) {
     numResizes = 1;
   }
 

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -16,14 +16,14 @@
 
 #pragma once
 
-template <typename KeyT, typename ValueT>
-void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::resize() {
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
+void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::resize() {
   dynamic_allocator_->growPool();
   gpu_context_.updateAllocatorContext(dynamic_allocator_->getContextPtr());
 }
 
-template <typename KeyT, typename ValueT>
-uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::checkForPreemptiveResize(uint32_t keysAdded) {
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
+uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::checkForPreemptiveResize(uint32_t keysAdded) {
   auto numSlabs = gpu_context_.getTotalNumSlabs();
   
   auto capacity = numSlabs * 16; // capacity in key-value size multiples
@@ -39,8 +39,8 @@ uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::checkForPreemp
   return numResizes;
 }
 
-template <typename KeyT, typename ValueT>
-void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::buildBulk(
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
+void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::buildBulk(
     KeyT* d_key,
     ValueT* d_value,
     uint32_t num_keys) {
@@ -63,8 +63,8 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::buildBulk(
   gpu_context_.updateTotalNumKeys(num_keys);
 }
 
-template <typename KeyT, typename ValueT>
-void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::buildBulkWithUniqueKeys(
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
+void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::buildBulkWithUniqueKeys(
   KeyT* d_key,
   ValueT* d_value,
   uint32_t num_keys) {
@@ -91,8 +91,8 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::buildBulkWithUniqu
   //std::cout << "num_successes: " << *num_successes << std::endl;
 }
 
-template <typename KeyT, typename ValueT>
-void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::searchIndividual(
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
+void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::searchIndividual(
     KeyT* d_query,
     ValueT* d_result,
     uint32_t num_queries) {
@@ -102,8 +102,8 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::searchIndividual(
       <<<num_blocks, BLOCKSIZE_>>>(d_query, d_result, num_queries, gpu_context_);
 }
 
-template <typename KeyT, typename ValueT>
-void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::searchBulk(
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
+void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::searchBulk(
     KeyT* d_query,
     ValueT* d_result,
     uint32_t num_queries) {
@@ -113,8 +113,8 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::searchBulk(
       <<<num_blocks, BLOCKSIZE_>>>(d_query, d_result, num_queries, gpu_context_);
 }
 
-template <typename KeyT, typename ValueT>
-void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::countIndividual(
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
+void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::countIndividual(
     KeyT* d_query,
     uint32_t* d_count,
     uint32_t num_queries) {
@@ -124,8 +124,8 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::countIndividual(
       <<<num_blocks, BLOCKSIZE_>>>(d_query, d_count, num_queries, gpu_context_);
 }
 
-template <typename KeyT, typename ValueT>
-void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::deleteIndividual(
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
+void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::deleteIndividual(
     KeyT* d_key,
     uint32_t num_keys) {
   CHECK_CUDA_ERROR(cudaSetDevice(device_idx_));
@@ -135,8 +135,8 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::deleteIndividual(
 }
 
 // perform a batch of (a mixture of) updates/searches
-template <typename KeyT, typename ValueT>
-void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::batchedOperation(
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
+void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::batchedOperation(
     KeyT* d_key,
     ValueT* d_result,
     uint32_t num_ops) {
@@ -146,8 +146,8 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::batchedOperation(
       <<<num_blocks, BLOCKSIZE_>>>(d_key, d_result, num_ops, gpu_context_);
 }
 
-template <typename KeyT, typename ValueT>
-std::string GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::to_string() {
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
+std::string GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::to_string() {
   std::string result;
   result += " ==== GpuSlabHash: \n";
   result += "\t Running on device \t\t " + std::to_string(device_idx_) + "\n";
@@ -161,8 +161,8 @@ std::string GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::to_string()
   return result;
 }
 
-template <typename KeyT, typename ValueT>
-double GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::computeLoadFactor(
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
+double GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::computeLoadFactor(
     int flag = 0) {
   uint32_t* h_bucket_pairs_count = new uint32_t[num_buckets_];
   uint32_t* d_bucket_pairs_count;

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -30,11 +30,8 @@ uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::checkForPreemp
   auto finalSlabLoadFactor = (float) (finalNumKeys) / maxElemCapacity;
   auto numResizes = 0;
 
-  if(finalSlabLoadFactor > 0.85) {
+  if(finalSlabLoadFactor > 0.60) {
     numResizes = 1;
-  }
-  if(finalSlabLoadFactor > 1.95) {
-    numResizes = 2;
   }
 
   return numResizes;

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -25,6 +25,7 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::resize() {
 template <typename KeyT, typename ValueT>
 uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::checkForPreemptiveResize(uint32_t keysAdded) {
   auto numSlabs = gpu_context_.getTotalNumSlabs();
+  std::cout << "numSlabs " << numSlabs << std::endl;
   auto maxElemCapacity = numSlabs * 15;
   auto finalNumKeys = gpu_context_.getTotalNumKeys() + keysAdded;
   std::cout << "finalNumKeys " << finalNumKeys << std::endl;

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -32,7 +32,7 @@ uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::checkForPreemp
   auto finalSlabLoadFactor = (float) (finalNumKeys) / capacity;
   auto numResizes = 0;
 
-  if(finalSlabLoadFactor > 0.60) {
+  if(finalSlabLoadFactor > 0.65) {
     numResizes = 1;
   }
 

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -28,7 +28,7 @@ uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::checkForPreemp
   
   auto capacity = numSlabs * 16; // capacity in key-value size multiples
   auto finalNumKeys = gpu_context_.getTotalNumKeys() + keysAdded;
-  std::cout << "finalNumKeys " << finalNumKeys << std::endl;
+  //std::cout << "finalNumKeys " << finalNumKeys << std::endl;
   auto finalSlabLoadFactor = (float) (finalNumKeys) / capacity;
   auto numResizes = 0;
 

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -28,11 +28,11 @@ uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::checkForPreemp
   
   auto capacity = numSlabs * 16; // capacity in key-value size multiples
   auto finalNumKeys = gpu_context_.getTotalNumKeys() + keysAdded;
-  std::cout << "finalNumKeys " << finalNumKeys << std::endl;
+  //std::cout << "finalNumKeys " << finalNumKeys << std::endl;
   auto finalSlabLoadFactor = (float) (finalNumKeys) / capacity;
   auto numResizes = 0;
 
-  if(finalSlabLoadFactor > 1) {
+  if(finalSlabLoadFactor >= 0.90) {
     numResizes = 1;
   }
 

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -86,7 +86,7 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::buildBulkWithUniqu
   // now that the bulk insert has completed successfully, we can
   // update the total number of keys in the table
   gpu_context_.updateTotalNumKeys(*num_successes);
-  std::cout << "num_successes: " << *num_successes << std::endl;
+  //std::cout << "num_successes: " << *num_successes << std::endl;
 }
 
 template <typename KeyT, typename ValueT>

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -32,7 +32,7 @@ uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::checkForPreemp
   auto finalSlabLoadFactor = (float) (finalNumKeys) / capacity;
   auto numResizes = 0;
 
-  if(finalSlabLoadFactor >= 0.90) {
+  if(finalSlabLoadFactor >= 0.75) {
     numResizes = 1;
   }
 

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -33,7 +33,7 @@ uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::checkForPreemp
   auto finalSlabLoadFactor = (float) (finalNumKeys) / capacity;
   auto numResizes = 0;
 
-  if(finalSlabLoadFactor > 0.70) {
+  if(finalSlabLoadFactor > 0.60) {
     numResizes = 1;
   }
 

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -25,11 +25,11 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::resize() {
 template <typename KeyT, typename ValueT>
 uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::checkForPreemptiveResize(uint32_t keysAdded) {
   auto numSlabs = gpu_context_.getTotalNumSlabs();
-  std::cout << "numSlabs " << numSlabs << std::endl;
+  //std::cout << "numSlabs " << numSlabs << std::endl;
   
   auto capacity = numSlabs * 16; // capacity in key-value size multiples
   auto finalNumKeys = gpu_context_.getTotalNumKeys() + keysAdded;
-  std::cout << "finalNumKeys " << finalNumKeys << std::endl;
+  //åstd::cout << "finalNumKeys " << finalNumKeys << std::endl;
   auto finalSlabLoadFactor = (float) (finalNumKeys) / capacity;
   auto numResizes = 0;
 

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -28,11 +28,11 @@ uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::checkForPreemp
   
   auto capacity = numSlabs * 16; // capacity in key-value size multiples
   auto finalNumKeys = gpu_context_.getTotalNumKeys() + keysAdded;
-  //std::cout << "finalNumKeys " << finalNumKeys << std::endl;
+  std::cout << "finalNumKeys " << finalNumKeys << std::endl;
   auto finalSlabLoadFactor = (float) (finalNumKeys) / capacity;
   auto numResizes = 0;
 
-  if(finalSlabLoadFactor > 0.60) {
+  if(finalSlabLoadFactor > 1) {
     numResizes = 1;
   }
 

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -45,6 +45,8 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::buildBulk(
     KeyT* d_key,
     ValueT* d_value,
     uint32_t num_keys) {
+  
+  /*
   int h_retry = 1;
   int *d_retry;
   CHECK_CUDA_ERROR(cudaMalloc((void**)&d_retry, sizeof(int)));
@@ -52,10 +54,10 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::buildBulk(
   bool* d_success;
   CHECK_CUDA_ERROR(cudaMalloc((void**)&d_success, num_keys * sizeof(bool)));
   CHECK_CUDA_ERROR(cudaMemset((void*)d_success, 0x00, num_keys * sizeof(bool)));
-
+  */
   const uint32_t num_blocks = (num_keys + BLOCKSIZE_ - 1) / BLOCKSIZE_;
   CHECK_CUDA_ERROR(cudaSetDevice(device_idx_));
-  while(h_retry) {
+  //while(h_retry) {
     // predict whether resizing will be necessary, and take preemptive action.
     auto numResizes = checkForPreemptiveResize(num_keys);
     for(auto i = 0; i < numResizes; ++i) {
@@ -64,18 +66,20 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::buildBulk(
 
     // calling the kernel for bulk build:
     build_table_kernel<KeyT, ValueT>
-        <<<num_blocks, BLOCKSIZE_>>>(d_retry, d_success, d_key, d_value, num_keys, gpu_context_);
+        <<<num_blocks, BLOCKSIZE_>>>(/*d_retry, d_success,*/ d_key, d_value, num_keys, gpu_context_);
     CHECK_CUDA_ERROR(cudaDeviceSynchronize());
-    CHECK_CUDA_ERROR(cudaMemcpy(&h_retry, d_retry, sizeof(int), cudaMemcpyDeviceToHost));
+    //CHECK_CUDA_ERROR(cudaMemcpy(&h_retry, d_retry, sizeof(int), cudaMemcpyDeviceToHost));
     
     // resize the pool here if necessary
+    /*
     if(h_retry) {
       resize();
     }
     CHECK_CUDA_ERROR(cudaMemset((void*)d_retry, 0x00, sizeof(int)));
-  }
-  CHECK_CUDA_ERROR(cudaFree(d_retry));
-  CHECK_CUDA_ERROR(cudaFree(d_success));
+    */
+  //}
+  //CHECK_CUDA_ERROR(cudaFree(d_retry));
+  //CHECK_CUDA_ERROR(cudaFree(d_success));
   
   // now that the bulk insert has completed successfully, we can
   // update the total number of keys in the table
@@ -87,7 +91,8 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::buildBulkWithUniqu
     KeyT* d_key,
     ValueT* d_value,
     uint32_t num_keys) {
-
+  
+  /*
   int h_retry = 1;
   int *d_retry;
   CHECK_CUDA_ERROR(cudaMalloc((void**)&d_retry, sizeof(int)));
@@ -95,10 +100,10 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::buildBulkWithUniqu
   bool* d_success;
   CHECK_CUDA_ERROR(cudaMalloc((void**)&d_success, num_keys * sizeof(bool)));
   CHECK_CUDA_ERROR(cudaMemset((void*)d_success, 0x00, num_keys * sizeof(bool)));
-
+  */
   const uint32_t num_blocks = (num_keys + BLOCKSIZE_ - 1) / BLOCKSIZE_;
   CHECK_CUDA_ERROR(cudaSetDevice(device_idx_));
-  while(h_retry) {
+  //while(h_retry) {
     // predict whether resizing will be necessary, and take preemptive action.
     auto numResizes = checkForPreemptiveResize(num_keys);
     for(auto i = 0; i < numResizes; ++i) {
@@ -107,18 +112,20 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::buildBulkWithUniqu
 
     // calling the kernel for bulk build:
     build_table_with_unique_keys_kernel<KeyT, ValueT>
-        <<<num_blocks, BLOCKSIZE_>>>(d_retry, d_success, d_key, d_value, num_keys, gpu_context_);
+        <<<num_blocks, BLOCKSIZE_>>>(/*d_retry, d_success,*/ d_key, d_value, num_keys, gpu_context_);
     CHECK_CUDA_ERROR(cudaDeviceSynchronize());
-    CHECK_CUDA_ERROR(cudaMemcpy(&h_retry, d_retry, sizeof(int), cudaMemcpyDeviceToHost));
+    //CHECK_CUDA_ERROR(cudaMemcpy(&h_retry, d_retry, sizeof(int), cudaMemcpyDeviceToHost));
     
     // resize the pool here if necessary
+    /*
     if(h_retry) {
       resize();
     }
     CHECK_CUDA_ERROR(cudaMemset((void*)d_retry, 0x00, sizeof(int)));
-  }
-  CHECK_CUDA_ERROR(cudaFree(d_retry));
-  CHECK_CUDA_ERROR(cudaFree(d_success));
+    */
+  //}
+  //CHECK_CUDA_ERROR(cudaFree(d_retry));
+  //CHECK_CUDA_ERROR(cudaFree(d_success));
 
   // now that the bulk insert has completed successfully, we can
   // update the total number of keys in the table

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -32,7 +32,7 @@ uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::checkForPreemp
   auto finalSlabLoadFactor = (float) (finalNumKeys) / capacity;
   auto numResizes = 0;
 
-  if(finalSlabLoadFactor >= 0.75) {
+  if(finalSlabLoadFactor >= 0.60) {
     numResizes = 1;
   }
 

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -23,12 +23,12 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks,
 }
 
 template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
-uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::checkForPreemptiveResize(uint32_t keysAdded) {
+uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, 
+                     log_num_mem_blocks, num_super_blocks>::checkForPreemptiveResize(uint32_t keysAdded) {
   auto numSlabs = gpu_context_.getTotalNumSlabs();
   
   auto capacity = numSlabs * 16; // capacity in key-value size multiples
   auto finalNumKeys = gpu_context_.getTotalNumKeys() + keysAdded;
-  //std::cout << "finalNumKeys " << finalNumKeys << std::endl;
   auto finalSlabLoadFactor = (float) (finalNumKeys) / capacity;
   auto numResizes = 0;
 
@@ -40,7 +40,8 @@ uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blo
 }
 
 template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
-void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::buildBulk(
+void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, 
+                 log_num_mem_blocks, num_super_blocks>::buildBulk(
     KeyT* d_key,
     ValueT* d_value,
     uint32_t num_keys) {
@@ -53,7 +54,6 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks,
   }
 
   // calling the kernel for bulk build:
-  //int num_successes = 0;
   build_table_kernel<KeyT, ValueT>
       <<<num_blocks, BLOCKSIZE_>>>(d_key, d_value, num_keys, gpu_context_);
   CHECK_CUDA_ERROR(cudaDeviceSynchronize());
@@ -64,7 +64,8 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks,
 }
 
 template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
-void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::buildBulkWithUniqueKeys(
+void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, 
+                 log_num_mem_blocks, num_super_blocks>::buildBulkWithUniqueKeys(
   KeyT* d_key,
   ValueT* d_value,
   uint32_t num_keys) {
@@ -88,11 +89,11 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks,
   // now that the bulk insert has completed successfully, we can
   // update the total number of keys in the table
   gpu_context_.updateTotalNumKeys(*num_successes);
-  //std::cout << "num_successes: " << *num_successes << std::endl;
 }
 
 template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
-void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::searchIndividual(
+void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, 
+                 log_num_mem_blocks, num_super_blocks>::searchIndividual(
     KeyT* d_query,
     ValueT* d_result,
     uint32_t num_queries) {
@@ -103,7 +104,8 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks,
 }
 
 template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
-void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::searchBulk(
+void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, 
+                 log_num_mem_blocks, num_super_blocks>::searchBulk(
     KeyT* d_query,
     ValueT* d_result,
     uint32_t num_queries) {
@@ -114,7 +116,8 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks,
 }
 
 template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
-void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::countIndividual(
+void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, 
+                 log_num_mem_blocks, num_super_blocks>::countIndividual(
     KeyT* d_query,
     uint32_t* d_count,
     uint32_t num_queries) {
@@ -125,7 +128,8 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks,
 }
 
 template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
-void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::deleteIndividual(
+void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, 
+                 log_num_mem_blocks, num_super_blocks>::deleteIndividual(
     KeyT* d_key,
     uint32_t num_keys) {
   CHECK_CUDA_ERROR(cudaSetDevice(device_idx_));
@@ -136,7 +140,8 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks,
 
 // perform a batch of (a mixture of) updates/searches
 template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
-void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::batchedOperation(
+void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, 
+                 log_num_mem_blocks, num_super_blocks>::batchedOperation(
     KeyT* d_key,
     ValueT* d_result,
     uint32_t num_ops) {
@@ -147,7 +152,8 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks,
 }
 
 template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
-std::string GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::to_string() {
+std::string GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, 
+                        log_num_mem_blocks, num_super_blocks>::to_string() {
   std::string result;
   result += " ==== GpuSlabHash: \n";
   result += "\t Running on device \t\t " + std::to_string(device_idx_) + "\n";
@@ -162,7 +168,8 @@ std::string GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_
 }
 
 template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
-double GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::computeLoadFactor(
+double GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, 
+                   log_num_mem_blocks, num_super_blocks>::computeLoadFactor(
     int flag = 0) {
   uint32_t* h_bucket_pairs_count = new uint32_t[num_buckets_];
   uint32_t* d_bucket_pairs_count;

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -32,7 +32,7 @@ uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::checkForPreemp
   auto finalSlabLoadFactor = (float) (finalNumKeys) / capacity;
   auto numResizes = 0;
 
-  if(finalSlabLoadFactor >= 0.60) {
+  if(finalSlabLoadFactor >= 0.55) {
     numResizes = 1;
   }
 

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -32,7 +32,7 @@ uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::checkForPreemp
   auto finalSlabLoadFactor = (float) (finalNumKeys) / capacity;
   auto numResizes = 0;
 
-  if(finalSlabLoadFactor > 0.50) {
+  if(finalSlabLoadFactor > 0.60) {
     numResizes = 1;
   }
 

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -81,6 +81,8 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::buildBulkWithUniqu
   CHECK_CUDA_ERROR(cudaMallocManaged(&num_successes, sizeof(int)));
   *num_successes = 0;
 
+  std::cout << "hashes" << gpu_context_.getHashX() << ", " << gpu_context_.getHashY() << std::endl;
+
   build_table_with_unique_keys_kernel<KeyT, ValueT>
       <<<num_blocks, BLOCKSIZE_>>>(num_successes, d_key, d_value, num_keys, gpu_context_);
   CHECK_CUDA_ERROR(cudaDeviceSynchronize());

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -25,15 +25,15 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::resize() {
 template <typename KeyT, typename ValueT>
 uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::checkForPreemptiveResize(uint32_t keysAdded) {
   auto numSlabs = gpu_context_.getTotalNumSlabs();
-  std::cout << "numSlabs " << numSlabs << std::endl;
+  //std::cout << "numSlabs " << numSlabs << std::endl;
   
   auto capacity = numSlabs * 16; // capacity in key-value size multiples
   auto finalNumKeys = gpu_context_.getTotalNumKeys() + keysAdded;
-  std::cout << "finalNumKeys " << finalNumKeys << std::endl;
+  //std::cout << "finalNumKeys " << finalNumKeys << std::endl;
   auto finalSlabLoadFactor = (float) (finalNumKeys) / capacity;
   auto numResizes = 0;
 
-  if(finalSlabLoadFactor > 0.80) {
+  if(finalSlabLoadFactor > 0.70) {
     numResizes = 1;
   }
 

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -32,7 +32,7 @@ uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::checkForPreemp
   auto finalSlabLoadFactor = (float) (finalNumKeys) / capacity;
   auto numResizes = 0;
 
-  if(finalSlabLoadFactor >= 0.55) {
+  if(finalSlabLoadFactor >= 0.60) {
     numResizes = 1;
   }
 

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -27,6 +27,7 @@ uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::checkForPreemp
   auto numSlabs = gpu_context_.getTotalNumSlabs();
   auto maxElemCapacity = numSlabs * 15;
   auto finalNumKeys = gpu_context_.getTotalNumKeys() + keysAdded;
+  std::cout << "finalNumKeys " << finalNumKeys << std::endl;
   auto finalSlabLoadFactor = (float) (finalNumKeys) / maxElemCapacity;
   auto numResizes = 0;
 

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -32,7 +32,7 @@ uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blo
   auto finalSlabLoadFactor = (float) (finalNumKeys) / capacity;
   auto numResizes = 0;
 
-  if(finalSlabLoadFactor >= 0.90) {
+  if(finalSlabLoadFactor >= thresh_lf_) {
     numResizes = 1;
   }
 

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -33,7 +33,7 @@ uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::checkForPreemp
   auto finalSlabLoadFactor = (float) (finalNumKeys) / capacity;
   auto numResizes = 0;
 
-  if(finalSlabLoadFactor > 0.60) {
+  if(finalSlabLoadFactor > 0.50) {
     numResizes = 1;
   }
 

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -25,11 +25,11 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::resize() {
 template <typename KeyT, typename ValueT>
 uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::checkForPreemptiveResize(uint32_t keysAdded) {
   auto numSlabs = gpu_context_.getTotalNumSlabs();
-  //std::cout << "numSlabs " << numSlabs << std::endl;
+  std::cout << "numSlabs " << numSlabs << std::endl;
   
   auto capacity = numSlabs * 16; // capacity in key-value size multiples
   auto finalNumKeys = gpu_context_.getTotalNumKeys() + keysAdded;
-  //std::cout << "finalNumKeys " << finalNumKeys << std::endl;
+  std::cout << "finalNumKeys " << finalNumKeys << std::endl;
   auto finalSlabLoadFactor = (float) (finalNumKeys) / capacity;
   auto numResizes = 0;
 

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -46,40 +46,17 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::buildBulk(
     ValueT* d_value,
     uint32_t num_keys) {
   
-  /*
-  int h_retry = 1;
-  int *d_retry;
-  CHECK_CUDA_ERROR(cudaMalloc((void**)&d_retry, sizeof(int)));
-  CHECK_CUDA_ERROR(cudaMemset((void*)d_retry, 0x00, sizeof(int)));
-  bool* d_success;
-  CHECK_CUDA_ERROR(cudaMalloc((void**)&d_success, num_keys * sizeof(bool)));
-  CHECK_CUDA_ERROR(cudaMemset((void*)d_success, 0x00, num_keys * sizeof(bool)));
-  */
   const uint32_t num_blocks = (num_keys + BLOCKSIZE_ - 1) / BLOCKSIZE_;
   CHECK_CUDA_ERROR(cudaSetDevice(device_idx_));
-  //while(h_retry) {
-    // predict whether resizing will be necessary, and take preemptive action.
-    auto numResizes = checkForPreemptiveResize(num_keys);
-    for(auto i = 0; i < numResizes; ++i) {
-      resize();
-    }
+  auto numResizes = checkForPreemptiveResize(num_keys);
+  for(auto i = 0; i < numResizes; ++i) {
+    resize();
+  }
 
-    // calling the kernel for bulk build:
-    build_table_kernel<KeyT, ValueT>
-        <<<num_blocks, BLOCKSIZE_>>>(/*d_retry, d_success,*/ d_key, d_value, num_keys, gpu_context_);
-    CHECK_CUDA_ERROR(cudaDeviceSynchronize());
-    //CHECK_CUDA_ERROR(cudaMemcpy(&h_retry, d_retry, sizeof(int), cudaMemcpyDeviceToHost));
-    
-    // resize the pool here if necessary
-    /*
-    if(h_retry) {
-      resize();
-    }
-    CHECK_CUDA_ERROR(cudaMemset((void*)d_retry, 0x00, sizeof(int)));
-    */
-  //}
-  //CHECK_CUDA_ERROR(cudaFree(d_retry));
-  //CHECK_CUDA_ERROR(cudaFree(d_success));
+  // calling the kernel for bulk build:
+  build_table_kernel<KeyT, ValueT>
+      <<<num_blocks, BLOCKSIZE_>>>(/*d_retry, d_success,*/ d_key, d_value, num_keys, gpu_context_);
+  CHECK_CUDA_ERROR(cudaDeviceSynchronize());
   
   // now that the bulk insert has completed successfully, we can
   // update the total number of keys in the table
@@ -88,45 +65,22 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::buildBulk(
 
 template <typename KeyT, typename ValueT>
 void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::buildBulkWithUniqueKeys(
-    KeyT* d_key,
-    ValueT* d_value,
-    uint32_t num_keys) {
+  KeyT* d_key,
+  ValueT* d_value,
+  uint32_t num_keys) {
   
-  /*
-  int h_retry = 1;
-  int *d_retry;
-  CHECK_CUDA_ERROR(cudaMalloc((void**)&d_retry, sizeof(int)));
-  CHECK_CUDA_ERROR(cudaMemset((void*)d_retry, 0x00, sizeof(int)));
-  bool* d_success;
-  CHECK_CUDA_ERROR(cudaMalloc((void**)&d_success, num_keys * sizeof(bool)));
-  CHECK_CUDA_ERROR(cudaMemset((void*)d_success, 0x00, num_keys * sizeof(bool)));
-  */
   const uint32_t num_blocks = (num_keys + BLOCKSIZE_ - 1) / BLOCKSIZE_;
   CHECK_CUDA_ERROR(cudaSetDevice(device_idx_));
-  //while(h_retry) {
-    // predict whether resizing will be necessary, and take preemptive action.
-    auto numResizes = checkForPreemptiveResize(num_keys);
-    for(auto i = 0; i < numResizes; ++i) {
-      resize();
-    }
+  auto numResizes = checkForPreemptiveResize(num_keys);
+  for(auto i = 0; i < numResizes; ++i) {
+    resize();
+  }
 
-    // calling the kernel for bulk build:
-    build_table_with_unique_keys_kernel<KeyT, ValueT>
-        <<<num_blocks, BLOCKSIZE_>>>(/*d_retry, d_success,*/ d_key, d_value, num_keys, gpu_context_);
-    CHECK_CUDA_ERROR(cudaDeviceSynchronize());
-    //CHECK_CUDA_ERROR(cudaMemcpy(&h_retry, d_retry, sizeof(int), cudaMemcpyDeviceToHost));
-    
-    // resize the pool here if necessary
-    /*
-    if(h_retry) {
-      resize();
-    }
-    CHECK_CUDA_ERROR(cudaMemset((void*)d_retry, 0x00, sizeof(int)));
-    */
-  //}
-  //CHECK_CUDA_ERROR(cudaFree(d_retry));
-  //CHECK_CUDA_ERROR(cudaFree(d_success));
-
+  // calling the kernel for bulk build:
+  build_table_with_unique_keys_kernel<KeyT, ValueT>
+      <<<num_blocks, BLOCKSIZE_>>>(/*d_retry, d_success,*/ d_key, d_value, num_keys, gpu_context_);
+  CHECK_CUDA_ERROR(cudaDeviceSynchronize());
+  
   // now that the bulk insert has completed successfully, we can
   // update the total number of keys in the table
   gpu_context_.updateTotalNumKeys(num_keys);

--- a/src/concurrent_map/cmap_implementation.cuh
+++ b/src/concurrent_map/cmap_implementation.cuh
@@ -28,7 +28,7 @@ uint32_t GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::checkForPreemp
   
   auto capacity = numSlabs * 16; // capacity in key-value size multiples
   auto finalNumKeys = gpu_context_.getTotalNumKeys() + keysAdded;
-  //std::cout << "finalNumKeys " << finalNumKeys << std::endl;
+  std::cout << "finalNumKeys " << finalNumKeys << std::endl;
   auto finalSlabLoadFactor = (float) (finalNumKeys) / capacity;
   auto numResizes = 0;
 

--- a/src/concurrent_map/device/build.cuh
+++ b/src/concurrent_map/device/build.cuh
@@ -23,7 +23,8 @@ __global__ void build_table_kernel(
     KeyT* d_key,
     ValueT* d_value,
     uint32_t num_keys,
-    GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks> slab_hash) {
+    GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, 
+    log_num_mem_blocks, num_super_blocks> slab_hash) {
   uint32_t tid = threadIdx.x + blockIdx.x * blockDim.x;
   uint32_t laneId = threadIdx.x & 0x1F;
 
@@ -31,7 +32,8 @@ __global__ void build_table_kernel(
     return;
   }
 
-  SlabAllocLightContext<log_num_mem_blocks, num_super_blocks, 1> local_allocator_ctx(slab_hash.getAllocatorContext());
+  SlabAllocLightContext<log_num_mem_blocks, num_super_blocks, 1> 
+    local_allocator_ctx(slab_hash.getAllocatorContext());
   local_allocator_ctx.initAllocator(tid, laneId);
 
   KeyT myKey = 0;
@@ -55,7 +57,8 @@ __global__ void build_table_with_unique_keys_kernel(
     KeyT* d_key,
     ValueT* d_value,
     uint32_t num_keys,
-    GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks> slab_hash) {
+    GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, 
+    log_num_mem_blocks, num_super_blocks> slab_hash) {
   
   typedef cub::BlockReduce<std::size_t, 128> BlockReduce;
   __shared__ typename BlockReduce::TempStorage temp_storage;
@@ -63,11 +66,8 @@ __global__ void build_table_with_unique_keys_kernel(
   uint32_t tid = threadIdx.x + blockIdx.x * blockDim.x;
   uint32_t laneId = threadIdx.x & 0x1F;
 
-  //if ((tid - laneId) >= num_keys) {
-  //  return;
-  //}
-
-  SlabAllocLightContext<log_num_mem_blocks, num_super_blocks, 1> local_allocator_ctx(slab_hash.getAllocatorContext());
+  SlabAllocLightContext<log_num_mem_blocks, num_super_blocks, 1> 
+    local_allocator_ctx(slab_hash.getAllocatorContext());
   local_allocator_ctx.initAllocator(tid, laneId);
 
   KeyT myKey = 0;

--- a/src/concurrent_map/device/build.cuh
+++ b/src/concurrent_map/device/build.cuh
@@ -20,8 +20,6 @@
  */
 template <typename KeyT, typename ValueT>
 __global__ void build_table_kernel(
-    /*int* d_retry,*/
-    /*bool* d_success,*/
     KeyT* d_key,
     ValueT* d_value,
     uint32_t num_keys,
@@ -36,34 +34,23 @@ __global__ void build_table_kernel(
   AllocatorContextT local_allocator_ctx(slab_hash.getAllocatorContext());
   local_allocator_ctx.initAllocator(tid, laneId);
 
-  //bool mySuccess = true;
   KeyT myKey = 0;
   ValueT myValue = 0;
   uint32_t myBucket = 0;
   bool to_insert = false;
 
   if (tid < num_keys) {
-    //mySuccess = d_success[tid];
     myKey = d_key[tid];
     myValue = d_value[tid];
     myBucket = slab_hash.computeBucket(myKey);
     to_insert = true;
   }
 
-  slab_hash.insertPair(/*mySuccess,*/ to_insert, laneId, myKey, myValue, myBucket, local_allocator_ctx);
-  
-  /*
-  if (tid < num_keys) {
-    d_success[tid] = mySuccess;
-    atomicCAS(d_retry, 0, (int)!mySuccess); // if any key was not successful, we need to resize and retry
-  }
-  */
+  slab_hash.insertPair(to_insert, laneId, myKey, myValue, myBucket, local_allocator_ctx);
 }
 
 template <typename KeyT, typename ValueT>
 __global__ void build_table_with_unique_keys_kernel(
-    /*int* d_retry,*/
-    /*bool* d_success,*/
     KeyT* d_key,
     ValueT* d_value,
     uint32_t num_keys,
@@ -78,27 +65,18 @@ __global__ void build_table_with_unique_keys_kernel(
   AllocatorContextT local_allocator_ctx(slab_hash.getAllocatorContext());
   local_allocator_ctx.initAllocator(tid, laneId);
 
-  //bool mySuccess = true;
   KeyT myKey = 0;
   ValueT myValue = 0;
   uint32_t myBucket = 0;
   bool to_insert = false;
 
   if (tid < num_keys) {
-    //mySuccess = d_success[tid];
     myKey = d_key[tid];
     myValue = d_value[tid];
     myBucket = slab_hash.computeBucket(myKey);
     to_insert = true;
   }
 
-  slab_hash.insertPairUnique(/*mySuccess,*/
+  slab_hash.insertPairUnique(
       to_insert, laneId, myKey, myValue, myBucket, local_allocator_ctx);
-  
-  /*
-  if (tid < num_keys) {
-    d_success[tid] = mySuccess;
-    atomicCAS(d_retry, 0, (int)!mySuccess); // if any key was not successful, we need to resize and retry
-  }
-  */
 }

--- a/src/concurrent_map/device/build.cuh
+++ b/src/concurrent_map/device/build.cuh
@@ -51,8 +51,11 @@ __global__ void build_table_kernel(
   }
 
   slab_hash.insertPair(mySuccess, to_insert, laneId, myKey, myValue, myBucket, local_allocator_ctx);
-  d_success[tid] = mySuccess;
-  atomicCAS(d_retry, 0, (int)!mySuccess); // if any key was not successful, we need to resize and retry
+  
+  if (tid < num_keys) {
+    d_success[tid] = mySuccess;
+    atomicCAS(d_retry, 0, (int)!mySuccess); // if any key was not successful, we need to resize and retry
+  }
 }
 
 template <typename KeyT, typename ValueT>

--- a/src/concurrent_map/device/build.cuh
+++ b/src/concurrent_map/device/build.cuh
@@ -63,9 +63,9 @@ __global__ void build_table_with_unique_keys_kernel(
   uint32_t tid = threadIdx.x + blockIdx.x * blockDim.x;
   uint32_t laneId = threadIdx.x & 0x1F;
 
-  if ((tid - laneId) >= num_keys) {
-    return;
-  }
+  //if ((tid - laneId) >= num_keys) {
+  //  return;
+  //}
 
   AllocatorContextT local_allocator_ctx(slab_hash.getAllocatorContext());
   local_allocator_ctx.initAllocator(tid, laneId);
@@ -83,8 +83,10 @@ __global__ void build_table_with_unique_keys_kernel(
     to_insert = true;
   }
 
-  slab_hash.insertPairUnique(mySuccess,
-      to_insert, laneId, myKey, myValue, myBucket, local_allocator_ctx);
+  if ((tid - laneId) < num_keys) {
+    slab_hash.insertPairUnique(mySuccess,
+        to_insert, laneId, myKey, myValue, myBucket, local_allocator_ctx);
+  }
       
   std::size_t block_num_successes = BlockReduce(temp_storage).Sum(mySuccess);
   if(threadIdx.x == 0) {

--- a/src/concurrent_map/device/build.cuh
+++ b/src/concurrent_map/device/build.cuh
@@ -60,6 +60,8 @@ __global__ void build_table_kernel(
 
 template <typename KeyT, typename ValueT>
 __global__ void build_table_with_unique_keys_kernel(
+    int* d_retry,
+    bool* d_success,
     KeyT* d_key,
     ValueT* d_value,
     uint32_t num_keys,
@@ -74,18 +76,25 @@ __global__ void build_table_with_unique_keys_kernel(
   AllocatorContextT local_allocator_ctx(slab_hash.getAllocatorContext());
   local_allocator_ctx.initAllocator(tid, laneId);
 
+  bool mySuccess = true;
   KeyT myKey = 0;
   ValueT myValue = 0;
   uint32_t myBucket = 0;
   bool to_insert = false;
 
   if (tid < num_keys) {
+    mySuccess = d_success[tid];
     myKey = d_key[tid];
     myValue = d_value[tid];
     myBucket = slab_hash.computeBucket(myKey);
-    to_insert = true;
+    to_insert = !mySuccess;
   }
 
-  slab_hash.insertPairUnique(
+  slab_hash.insertPairUnique(mySuccess,
       to_insert, laneId, myKey, myValue, myBucket, local_allocator_ctx);
+
+  if (tid < num_keys) {
+    d_success[tid] = mySuccess;
+    atomicCAS(d_retry, 0, (int)!mySuccess); // if any key was not successful, we need to resize and retry
+  }
 }

--- a/src/concurrent_map/device/build.cuh
+++ b/src/concurrent_map/device/build.cuh
@@ -20,8 +20,8 @@
  */
 template <typename KeyT, typename ValueT>
 __global__ void build_table_kernel(
-    int* d_retry,
-    bool* d_success,
+    /*int* d_retry,*/
+    /*bool* d_success,*/
     KeyT* d_key,
     ValueT* d_value,
     uint32_t num_keys,
@@ -36,32 +36,34 @@ __global__ void build_table_kernel(
   AllocatorContextT local_allocator_ctx(slab_hash.getAllocatorContext());
   local_allocator_ctx.initAllocator(tid, laneId);
 
-  bool mySuccess = true;
+  //bool mySuccess = true;
   KeyT myKey = 0;
   ValueT myValue = 0;
   uint32_t myBucket = 0;
   bool to_insert = false;
 
   if (tid < num_keys) {
-    mySuccess = d_success[tid];
+    //mySuccess = d_success[tid];
     myKey = d_key[tid];
     myValue = d_value[tid];
     myBucket = slab_hash.computeBucket(myKey);
-    to_insert = !mySuccess;
+    to_insert = true;
   }
 
-  slab_hash.insertPair(mySuccess, to_insert, laneId, myKey, myValue, myBucket, local_allocator_ctx);
+  slab_hash.insertPair(/*mySuccess,*/ to_insert, laneId, myKey, myValue, myBucket, local_allocator_ctx);
   
+  /*
   if (tid < num_keys) {
     d_success[tid] = mySuccess;
     atomicCAS(d_retry, 0, (int)!mySuccess); // if any key was not successful, we need to resize and retry
   }
+  */
 }
 
 template <typename KeyT, typename ValueT>
 __global__ void build_table_with_unique_keys_kernel(
-    int* d_retry,
-    bool* d_success,
+    /*int* d_retry,*/
+    /*bool* d_success,*/
     KeyT* d_key,
     ValueT* d_value,
     uint32_t num_keys,
@@ -76,25 +78,27 @@ __global__ void build_table_with_unique_keys_kernel(
   AllocatorContextT local_allocator_ctx(slab_hash.getAllocatorContext());
   local_allocator_ctx.initAllocator(tid, laneId);
 
-  bool mySuccess = true;
+  //bool mySuccess = true;
   KeyT myKey = 0;
   ValueT myValue = 0;
   uint32_t myBucket = 0;
   bool to_insert = false;
 
   if (tid < num_keys) {
-    mySuccess = d_success[tid];
+    //mySuccess = d_success[tid];
     myKey = d_key[tid];
     myValue = d_value[tid];
     myBucket = slab_hash.computeBucket(myKey);
-    to_insert = !mySuccess;
+    to_insert = true;
   }
 
-  slab_hash.insertPairUnique(mySuccess,
+  slab_hash.insertPairUnique(/*mySuccess,*/
       to_insert, laneId, myKey, myValue, myBucket, local_allocator_ctx);
-
+  
+  /*
   if (tid < num_keys) {
     d_success[tid] = mySuccess;
     atomicCAS(d_retry, 0, (int)!mySuccess); // if any key was not successful, we need to resize and retry
   }
+  */
 }

--- a/src/concurrent_map/device/concurrent_kernel.cuh
+++ b/src/concurrent_map/device/concurrent_kernel.cuh
@@ -16,12 +16,12 @@
 
 #pragma once
 
-template <typename KeyT, typename ValueT>
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
 __global__ void batched_operations(
     uint32_t* d_operations,
     uint32_t* d_results,
     uint32_t num_operations,
-    GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap> slab_hash) {
+    GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks> slab_hash) {
   uint32_t tid = threadIdx.x + blockIdx.x * blockDim.x;
   uint32_t laneId = threadIdx.x & 0x1F;
 
@@ -29,7 +29,7 @@ __global__ void batched_operations(
     return;
 
   // initializing the memory allocator on each warp:
-  AllocatorContextT local_allocator_ctx(slab_hash.getAllocatorContext());
+  SlabAllocLightContext<log_num_mem_blocks, num_super_blocks, 1> local_allocator_ctx(slab_hash.getAllocatorContext());
   local_allocator_ctx.initAllocator(tid, laneId);
 
   uint32_t myOperation = 0;

--- a/src/concurrent_map/device/count_kernel.cuh
+++ b/src/concurrent_map/device/count_kernel.cuh
@@ -16,12 +16,12 @@
 
 #pragma once
 
-template <typename KeyT, typename ValueT>
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
 __global__ void count_key(
     KeyT* d_queries,
     uint32_t* d_counts,
     uint32_t num_queries,
-    GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap> slab_hash) {
+    GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks> slab_hash) {
   uint32_t tid = threadIdx.x + blockIdx.x * blockDim.x;
   uint32_t laneId = threadIdx.x & 0x1F;
 

--- a/src/concurrent_map/device/delete_kernel.cuh
+++ b/src/concurrent_map/device/delete_kernel.cuh
@@ -16,11 +16,11 @@
 
 #pragma once
 
-template <typename KeyT, typename ValueT>
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
 __global__ void delete_table_keys(
     KeyT* d_key_deleted,
     uint32_t num_keys,
-    GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap> slab_hash) {
+    GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks> slab_hash) {
   uint32_t tid = threadIdx.x + blockIdx.x * blockDim.x;
   uint32_t laneId = threadIdx.x & 0x1F;
 

--- a/src/concurrent_map/device/misc_kernels.cuh
+++ b/src/concurrent_map/device/misc_kernels.cuh
@@ -21,9 +21,9 @@
  * slabs per bucket. The final results per bucket is stored in d_pairs_count_result and
  * d_slabs_count_result arrays respectively
  */
-template <typename KeyT, typename ValueT>
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
 __global__ void bucket_count_kernel(
-    GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap> slab_hash,
+    GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks> slab_hash,
     uint32_t* d_pairs_count_result,
     uint32_t* d_slabs_count_result,
     uint32_t num_buckets) {

--- a/src/concurrent_map/device/search_kernel.cuh
+++ b/src/concurrent_map/device/search_kernel.cuh
@@ -17,12 +17,12 @@
 #pragma once
 
 //=== Individual search kernel:
-template <typename KeyT, typename ValueT>
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
 __global__ void search_table(
     KeyT* d_queries,
     ValueT* d_results,
     uint32_t num_queries,
-    GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap> slab_hash) {
+    GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks> slab_hash) {
   uint32_t tid = threadIdx.x + blockIdx.x * blockDim.x;
   uint32_t laneId = threadIdx.x & 0x1F;
 
@@ -49,12 +49,12 @@ __global__ void search_table(
 }
 
 //=== Bulk search kernel:
-template <typename KeyT, typename ValueT>
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
 __global__ void search_table_bulk(
     KeyT* d_queries,
     ValueT* d_results,
     uint32_t num_queries,
-    GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap> slab_hash) {
+    GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks> slab_hash) {
   uint32_t tid = threadIdx.x + blockIdx.x * blockDim.x;
   uint32_t laneId = threadIdx.x & 0x1F;
 

--- a/src/concurrent_map/warp/count.cuh
+++ b/src/concurrent_map/warp/count.cuh
@@ -19,9 +19,9 @@
 //================================================
 // Individual Count Unit:
 //================================================
-template <typename KeyT, typename ValueT>
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
 __device__ __forceinline__ void
-GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::countKey(
+GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::countKey(
     bool& to_be_searched,
     const uint32_t& laneId,
     const KeyT& myKey,

--- a/src/concurrent_map/warp/delete.cuh
+++ b/src/concurrent_map/warp/delete.cuh
@@ -16,9 +16,9 @@
 
 #pragma once
 
-template <typename KeyT, typename ValueT>
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
 __device__ __forceinline__ bool
-GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::deleteKey(
+GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::deleteKey(
     bool& to_be_deleted,
     const uint32_t& laneId,
     const KeyT& myKey,

--- a/src/concurrent_map/warp/insert.cuh
+++ b/src/concurrent_map/warp/insert.cuh
@@ -193,7 +193,7 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::insertPairUnique
                             *reinterpret_cast<const uint32_t*>(
                                 reinterpret_cast<const unsigned char*>(&myKey)));
           if (old_key_value_pair == EMPTY_PAIR_64) {
-            mySuccess = 1;
+            mySuccess += 1;
             to_be_inserted = false;  // successful insertion
             new_insertion = true;
           }

--- a/src/concurrent_map/warp/insert.cuh
+++ b/src/concurrent_map/warp/insert.cuh
@@ -58,6 +58,7 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::insertPair(
         if(new_node_ptr == 0xFFFFFFFF) { // could not allocate a new slab: pool size needs to be increased
           mySuccess = false; // signal that this key needs to be reinserted 
           to_be_inserted = false;
+          continue;
         }
 
         // TODO: experiment if it's better to use lane 0 instead

--- a/src/concurrent_map/warp/insert.cuh
+++ b/src/concurrent_map/warp/insert.cuh
@@ -146,7 +146,6 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::insertPairUnique
                           SlabHashT::REGULAR_NODE_KEY_MASK;
     if (isExisting) {  // key exist in the hash table
       if (laneId == src_lane) {
-        mySuccess = 0;
         to_be_inserted = false;
       }
     } else {
@@ -156,7 +155,6 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::insertPairUnique
           // allocate a new node:
           uint32_t new_node_ptr = allocateSlab(local_allocator_ctx, laneId);
           if(new_node_ptr == 0xFFFFFFFF) { // could not allocate a new slab: pool size needs to be increased
-            mySuccess = 0; // signal that this key needs to be reinserted 
             to_be_inserted = false;
             continue;
           }

--- a/src/concurrent_map/warp/insert.cuh
+++ b/src/concurrent_map/warp/insert.cuh
@@ -56,7 +56,7 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::insertPair(
         // allocate a new node:
         uint32_t new_node_ptr = allocateSlab(local_allocator_ctx, laneId);
         if(new_node_ptr == 0xFFFFFFFF) { // could not allocate a new slab: pool size needs to be increased
-          mySuccess = true; // signal that this key needs to be reinserted 
+          mySuccess = false; // signal that this key needs to be reinserted 
           to_be_inserted = false;
         }
 
@@ -92,9 +92,10 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::insertPair(
                        << 32) |
                           *reinterpret_cast<const uint32_t*>(
                               reinterpret_cast<const unsigned char*>(&myKey)));
-        if (old_key_value_pair == EMPTY_PAIR_64)
+        if (old_key_value_pair == EMPTY_PAIR_64) {
           mySuccess = true;
           to_be_inserted = false;  // successful insertion
+        }
       }
     }
     last_work_queue = work_queue;

--- a/src/concurrent_map/warp/insert.cuh
+++ b/src/concurrent_map/warp/insert.cuh
@@ -21,16 +21,16 @@
  * it is assumed all threads within a warp are present and collaborating with
  * each other with a warp-cooperative work sharing (WCWS) strategy.
  */
-template <typename KeyT, typename ValueT>
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
 __device__ __forceinline__ void
-GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::insertPair(
+GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::insertPair(
     /*bool& mySuccess,*/
     bool& to_be_inserted,
     const uint32_t& laneId,
     const KeyT& myKey,
     const ValueT& myValue,
     const uint32_t bucket_id,
-    AllocatorContextT& local_allocator_ctx) {
+    SlabAllocLightContext<log_num_mem_blocks, num_super_blocks>& local_allocator_ctx) {
   using SlabHashT = ConcurrentMapT<KeyT, ValueT>;
   uint32_t work_queue = 0;
   uint32_t last_work_queue = 0;
@@ -110,16 +110,16 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::insertPair(
  * each other with a warp-cooperative work sharing (WCWS) strategy.
  * returns true only if a new key was inserted into the hash table
  */
-template <typename KeyT, typename ValueT>
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
 __device__ __forceinline__ bool
-GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::insertPairUnique(
+GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::insertPairUnique(
     int& mySuccess,
     bool& to_be_inserted,
     const uint32_t& laneId,
     const KeyT& myKey,
     const ValueT& myValue,
     const uint32_t bucket_id,
-    AllocatorContextT& local_allocator_ctx) {
+    SlabAllocLightContext<log_num_mem_blocks, num_super_blocks, 1>& local_allocator_ctx) {
 
   using SlabHashT = ConcurrentMapT<KeyT, ValueT>;
   uint32_t work_queue = 0;

--- a/src/concurrent_map/warp/insert.cuh
+++ b/src/concurrent_map/warp/insert.cuh
@@ -24,7 +24,7 @@
 template <typename KeyT, typename ValueT>
 __device__ __forceinline__ void
 GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::insertPair(
-    bool& mySuccess,
+    /*bool& mySuccess,*/
     bool& to_be_inserted,
     const uint32_t& laneId,
     const KeyT& myKey,
@@ -56,7 +56,7 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::insertPair(
         // allocate a new node:
         uint32_t new_node_ptr = allocateSlab(local_allocator_ctx, laneId);
         if(new_node_ptr == 0xFFFFFFFF) { // could not allocate a new slab: pool size needs to be increased
-          mySuccess = false; // signal that this key needs to be reinserted 
+          //mySuccess = false; // signal that this key needs to be reinserted 
           to_be_inserted = false;
           continue;
         }
@@ -94,7 +94,7 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::insertPair(
                           *reinterpret_cast<const uint32_t*>(
                               reinterpret_cast<const unsigned char*>(&myKey)));
         if (old_key_value_pair == EMPTY_PAIR_64) {
-          mySuccess = true;
+          //mySuccess = true;
           to_be_inserted = false;  // successful insertion
         }
       }
@@ -113,7 +113,7 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::insertPair(
 template <typename KeyT, typename ValueT>
 __device__ __forceinline__ bool
 GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::insertPairUnique(
-    bool& mySuccess,
+    /*bool& mySuccess,*/
     bool& to_be_inserted,
     const uint32_t& laneId,
     const KeyT& myKey,
@@ -145,7 +145,7 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::insertPairUnique
                           SlabHashT::REGULAR_NODE_KEY_MASK;
     if (isExisting) {  // key exist in the hash table
       if (laneId == src_lane) {
-        mySuccess = true;
+        //mySuccess = true;
         to_be_inserted = false;
       }
     } else {
@@ -155,7 +155,7 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::insertPairUnique
           // allocate a new node:
           uint32_t new_node_ptr = allocateSlab(local_allocator_ctx, laneId);
           if(new_node_ptr == 0xFFFFFFFF) { // could not allocate a new slab: pool size needs to be increased
-            mySuccess = false; // signal that this key needs to be reinserted 
+            //mySuccess = false; // signal that this key needs to be reinserted 
             to_be_inserted = false;
             continue;
           }
@@ -192,7 +192,7 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::insertPairUnique
                             *reinterpret_cast<const uint32_t*>(
                                 reinterpret_cast<const unsigned char*>(&myKey)));
           if (old_key_value_pair == EMPTY_PAIR_64) {
-            mySuccess = true;
+            //mySuccess = true;
             to_be_inserted = false;  // successful insertion
             new_insertion = true;
           }

--- a/src/concurrent_map/warp/search.cuh
+++ b/src/concurrent_map/warp/search.cuh
@@ -19,9 +19,9 @@
 //================================================
 // Individual Search Unit:
 //================================================
-template <typename KeyT, typename ValueT>
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
 __device__ __forceinline__ void
-GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::searchKey(
+GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::searchKey(
     bool& to_be_searched,
     const uint32_t& laneId,
     const KeyT& myKey,
@@ -73,9 +73,9 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::searchKey(
 //================================================
 // Bulk Search Unit:
 //================================================
-template <typename KeyT, typename ValueT>
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
 __device__ __forceinline__ void
-GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::searchKeyBulk(
+GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::searchKeyBulk(
     const uint32_t& laneId,
     const KeyT& myKey,
     ValueT& myValue,

--- a/src/concurrent_set/cset_class.cuh
+++ b/src/concurrent_set/cset_class.cuh
@@ -22,7 +22,8 @@
  * (i.e., d_table_)
  */
 template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
-class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet, log_num_mem_blocks, num_super_blocks> {
+class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet, 
+                         log_num_mem_blocks, num_super_blocks> {
  public:
   // fixed known parameters:
   static constexpr uint32_t PRIME_DIVISOR_ = 4294967291u;
@@ -36,7 +37,8 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet, log_num_mem
 
 #pragma hd_warning_disable
   __host__ __device__ GpuSlabHashContext(
-      GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet, log_num_mem_blocks, num_super_blocks>& rhs) {
+      GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet, 
+                         log_num_mem_blocks, num_super_blocks>& rhs) {
     num_buckets_ = rhs.getNumBuckets();
     hash_x_ = rhs.getHashX();
     hash_y_ = rhs.getHashY();
@@ -57,7 +59,8 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet, log_num_mem
                                const uint32_t hash_x,
                                const uint32_t hash_y,
                                int8_t* d_table,
-                               SlabAllocLightContext<log_num_mem_blocks, num_super_blocks, 1>* allocator_ctx) {
+                               SlabAllocLightContext<log_num_mem_blocks, 
+                               num_super_blocks, 1>* allocator_ctx) {
     num_buckets_ = num_buckets;
     hash_x_ = hash_x;
     hash_y_ = hash_y;
@@ -65,7 +68,8 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet, log_num_mem
     global_allocator_ctx_ = *allocator_ctx;
   }
 
-  __device__ __host__ __forceinline__ SlabAllocLightContext<log_num_mem_blocks, num_super_blocks, 1>& getAllocatorContext() {
+  __device__ __host__ __forceinline__ SlabAllocLightContext<log_num_mem_blocks, 
+    num_super_blocks, 1>& getAllocatorContext() {
     return global_allocator_ctx_;
   }
 
@@ -88,7 +92,8 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet, log_num_mem
                                             const uint32_t& laneId,
                                             const KeyT& myKey,
                                             const uint32_t bucket_id,
-                                            SlabAllocLightContext<log_num_mem_blocks, num_super_blocks, 1>& local_allocator_context);
+                                            SlabAllocLightContext<log_num_mem_blocks, num_super_blocks, 1>& 
+                                            local_allocator_context);
 
   // threads in a warp cooeparte with each other to search for keys
   // if found, it returns the true, else false
@@ -124,7 +129,8 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet, log_num_mem
   }
 
   __device__ __forceinline__ SlabAllocAddressT
-  allocateSlab(SlabAllocLightContext<log_num_mem_blocks, num_super_blocks, 1>& local_allocator_ctx, const uint32_t& laneId) {
+  allocateSlab(SlabAllocLightContext<log_num_mem_blocks, num_super_blocks, 1>& 
+    local_allocator_ctx, const uint32_t& laneId) {
     return local_allocator_ctx.warpAllocate(laneId);
   }
 
@@ -168,7 +174,8 @@ class GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentSet, log_num_mem_blocks
 
   // slab hash context, contains everything that a GPU application needs to be
   // able to use this data structure
-  GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet, log_num_mem_blocks, num_super_blocks> gpu_context_;
+  GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet, 
+                     log_num_mem_blocks, num_super_blocks> gpu_context_;
 
   // const pointer to an allocator that all instances of slab hash are going to
   // use. The allocator itself is not owned by this class
@@ -198,7 +205,8 @@ class GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentSet, log_num_mem_blocks
     CHECK_CUDA_ERROR(cudaSetDevice(device_idx_));
 
     slab_unit_size_ =
-        GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::getSlabUnitSize();
+        GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, 
+                           log_num_mem_blocks, num_super_blocks>::getSlabUnitSize();
 
     // allocating initial buckets:
     CHECK_CUDA_ERROR(cudaMalloc((void**)&d_table_, slab_unit_size_ * num_buckets_));
@@ -229,7 +237,8 @@ class GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentSet, log_num_mem_blocks
   // returns some debug information about the slab hash
   std::string to_string();
   double computeLoadFactor(int flag) {}
-  GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet, log_num_mem_blocks, num_super_blocks>& getSlabHashContext() {
+  GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet, 
+                     log_num_mem_blocks, num_super_blocks>& getSlabHashContext() {
     return gpu_context_;
   }
 

--- a/src/concurrent_set/cset_class.cuh
+++ b/src/concurrent_set/cset_class.cuh
@@ -180,7 +180,8 @@ class GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentSet, log_num_mem_blocks
               SlabAllocLight<log_num_mem_blocks, num_super_blocks, 1>* dynamic_allocator,
               uint32_t device_idx,
               const time_t seed = 0,
-              const bool identity_hash = false)
+              const bool identity_hash = false,
+              float thresh_lf = 0.60)
       : num_buckets_(num_buckets)
       , d_table_(nullptr)
       , slab_unit_size_(0)

--- a/src/concurrent_set/cset_class.cuh
+++ b/src/concurrent_set/cset_class.cuh
@@ -21,8 +21,8 @@
  * used at runtime. This class does not own the allocated memory on the gpu
  * (i.e., d_table_)
  */
-template <typename KeyT, typename ValueT>
-class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet> {
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
+class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet, log_num_mem_blocks, num_super_blocks> {
  public:
   // fixed known parameters:
   static constexpr uint32_t PRIME_DIVISOR_ = 4294967291u;
@@ -36,7 +36,7 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet> {
 
 #pragma hd_warning_disable
   __host__ __device__ GpuSlabHashContext(
-      GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>& rhs) {
+      GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet, log_num_mem_blocks, num_super_blocks>& rhs) {
     num_buckets_ = rhs.getNumBuckets();
     hash_x_ = rhs.getHashX();
     hash_y_ = rhs.getHashY();
@@ -57,7 +57,7 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet> {
                                const uint32_t hash_x,
                                const uint32_t hash_y,
                                int8_t* d_table,
-                               AllocatorContextT* allocator_ctx) {
+                               SlabAllocLightContext<log_num_mem_blocks, num_super_blocks, 1>* allocator_ctx) {
     num_buckets_ = num_buckets;
     hash_x_ = hash_x;
     hash_y_ = hash_y;
@@ -65,7 +65,7 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet> {
     global_allocator_ctx_ = *allocator_ctx;
   }
 
-  __device__ __host__ __forceinline__ AllocatorContextT& getAllocatorContext() {
+  __device__ __host__ __forceinline__ SlabAllocLightContext<log_num_mem_blocks, num_super_blocks, 1>& getAllocatorContext() {
     return global_allocator_ctx_;
   }
 
@@ -88,7 +88,7 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet> {
                                             const uint32_t& laneId,
                                             const KeyT& myKey,
                                             const uint32_t bucket_id,
-                                            AllocatorContextT& local_allocator_context);
+                                            SlabAllocLightContext<log_num_mem_blocks, num_super_blocks, 1>& local_allocator_context);
 
   // threads in a warp cooeparte with each other to search for keys
   // if found, it returns the true, else false
@@ -124,7 +124,7 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet> {
   }
 
   __device__ __forceinline__ SlabAllocAddressT
-  allocateSlab(AllocatorContextT& local_allocator_ctx, const uint32_t& laneId) {
+  allocateSlab(SlabAllocLightContext<log_num_mem_blocks, num_super_blocks, 1>& local_allocator_ctx, const uint32_t& laneId) {
     return local_allocator_ctx.warpAllocate(laneId);
   }
 
@@ -139,14 +139,14 @@ class GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet> {
   uint32_t hash_y_;
   typename ConcurrentSetT<KeyT>::SlabTypeT* d_table_;
   // a copy of dynamic allocator's context to be used on the GPU
-  AllocatorContextT global_allocator_ctx_;
+  SlabAllocLightContext<log_num_mem_blocks, num_super_blocks, 1> global_allocator_ctx_;
 };
 
 /*
  * This class owns the allocated memory for the hash table
  */
-template <typename KeyT, typename ValueT>
-class GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentSet> {
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
+class GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentSet, log_num_mem_blocks, num_super_blocks> {
  private:
   // fixed known parameters:
   static constexpr uint32_t BLOCKSIZE_ = 128;
@@ -168,16 +168,16 @@ class GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentSet> {
 
   // slab hash context, contains everything that a GPU application needs to be
   // able to use this data structure
-  GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet> gpu_context_;
+  GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet, log_num_mem_blocks, num_super_blocks> gpu_context_;
 
   // const pointer to an allocator that all instances of slab hash are going to
   // use. The allocator itself is not owned by this class
-  DynamicAllocatorT* dynamic_allocator_;
+  SlabAllocLight<log_num_mem_blocks, num_super_blocks, 1>* dynamic_allocator_;
   uint32_t device_idx_;
 
  public:
   GpuSlabHash(const uint32_t num_buckets,
-              DynamicAllocatorT* dynamic_allocator,
+              SlabAllocLight<log_num_mem_blocks, num_super_blocks, 1>* dynamic_allocator,
               uint32_t device_idx,
               const time_t seed = 0,
               const bool identity_hash = false)
@@ -197,7 +197,7 @@ class GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentSet> {
     CHECK_CUDA_ERROR(cudaSetDevice(device_idx_));
 
     slab_unit_size_ =
-        GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap>::getSlabUnitSize();
+        GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentMap, log_num_mem_blocks, num_super_blocks>::getSlabUnitSize();
 
     // allocating initial buckets:
     CHECK_CUDA_ERROR(cudaMalloc((void**)&d_table_, slab_unit_size_ * num_buckets_));
@@ -228,7 +228,7 @@ class GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentSet> {
   // returns some debug information about the slab hash
   std::string to_string();
   double computeLoadFactor(int flag) {}
-  GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>& getSlabHashContext() {
+  GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet, log_num_mem_blocks, num_super_blocks>& getSlabHashContext() {
     return gpu_context_;
   }
 

--- a/src/concurrent_set/cset_implementation.cuh
+++ b/src/concurrent_set/cset_implementation.cuh
@@ -16,8 +16,8 @@
 
 #pragma once
 
-template <typename KeyT, typename ValueT>
-void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>::buildBulk(
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
+void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentSet, log_num_mem_blocks, num_super_blocks>::buildBulk(
     KeyT* d_key,
     ValueT* d_value,
     uint32_t num_keys) {
@@ -28,8 +28,8 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>::buildBulk(
       <<<num_blocks, BLOCKSIZE_>>>(d_key, num_keys, gpu_context_);
 }
 
-template <typename KeyT, typename ValueT>
-void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>::searchIndividual(
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
+void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentSet, log_num_mem_blocks, num_super_blocks>::searchIndividual(
     KeyT* d_query,
     ValueT* d_result,
     uint32_t num_queries) {
@@ -39,8 +39,8 @@ void GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>::searchIndividual(
       <<<num_blocks, BLOCKSIZE_>>>(d_query, d_result, num_queries, gpu_context_);
 }
 
-template <typename KeyT, typename ValueT>
-std::string GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>::to_string() {
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
+std::string GpuSlabHash<KeyT, ValueT, SlabHashTypeT::ConcurrentSet, log_num_mem_blocks, num_super_blocks>::to_string() {
   std::string result;
   result += " ==== GpuSlabHash: \n";
   result += "\t Running on device \t\t " + std::to_string(device_idx_) + "\n";

--- a/src/concurrent_set/cset_warp_operations.cuh
+++ b/src/concurrent_set/cset_warp_operations.cuh
@@ -16,14 +16,14 @@
 
 #pragma once
 
-template <typename KeyT, typename ValueT>
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
 __device__ __forceinline__ bool
-GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>::insertKey(
+GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet, log_num_mem_blocks, num_super_blocks>::insertKey(
     bool& to_be_inserted,
     const uint32_t& laneId,
     const KeyT& myKey,
     const uint32_t bucket_id,
-    AllocatorContextT& local_allocator_ctx) {
+    SlabAllocLightContext<log_num_mem_blocks, num_super_blocks, 1>& local_allocator_ctx) {
   using SlabHashT = ConcurrentSetT<KeyT>;
   uint32_t work_queue = 0;
   uint32_t last_work_queue = 0;
@@ -91,9 +91,9 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>::insertKey(
 }
 
 // ========
-template <typename KeyT, typename ValueT>
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
 __device__ __forceinline__ bool
-GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>::searchKey(
+GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet, log_num_mem_blocks, num_super_blocks>::searchKey(
     bool& to_be_searched,
     const uint32_t& laneId,
     const KeyT& myKey,
@@ -138,9 +138,9 @@ GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>::searchKey(
   return myResult;
 }
 
-template <typename KeyT, typename ValueT>
+template <typename KeyT, typename ValueT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
 __device__ __forceinline__ bool
-GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet>::searchKeyBulk(
+GpuSlabHashContext<KeyT, ValueT, SlabHashTypeT::ConcurrentSet, log_num_mem_blocks, num_super_blocks>::searchKeyBulk(
     const uint32_t& laneId,
     const KeyT& myKey,
     const uint32_t bucket_id) {}

--- a/src/gpu_hash_table.cuh
+++ b/src/gpu_hash_table.cuh
@@ -21,7 +21,8 @@
  * This class acts as a helper class to simplify simulations around different
  * kinds of slab hash implementations
  */
-template <typename KeyT, typename ValueT, SlabHashTypeT SlabHashT>
+template <typename KeyT, typename ValueT, SlabHashTypeT SlabHashT, 
+          uint32_t log_num_mem_blocks=9, uint32_t num_super_blocks=1>
 class gpu_hash_table {
  private:
   uint32_t max_keys_;
@@ -32,10 +33,13 @@ class gpu_hash_table {
 
  public:
   // Slab hash invariant
-  GpuSlabHash<KeyT, ValueT, SlabHashT>* slab_hash_;
+  GpuSlabHash<KeyT, ValueT, SlabHashT, log_num_mem_blocks, num_super_blocks>* slab_hash_;
+
+  SlabAllocLight<log_num_mem_blocks, num_super_blocks, 1>* dynamic_allocator_;
 
   // the dynamic allocator that is being used for slab hash
-  DynamicAllocatorT* dynamic_allocator_;
+  //DynamicAllocatorT* dynamic_allocator_;
+
 
   uint32_t device_idx_;
 
@@ -77,10 +81,11 @@ class gpu_hash_table {
     //CHECK_CUDA_ERROR(cudaMalloc((void**)&d_count_, sizeof(uint32_t) * max_keys_));
     
     // allocate an initialize the allocator:
-    dynamic_allocator_ = new DynamicAllocatorT();
+    //dynamic_allocator_ = new DynamicAllocatorT();
+    dynamic_allocator_ = new SlabAllocLight<log_num_mem_blocks, num_super_blocks, 1>;
 
     // slab hash:
-    slab_hash_ = new GpuSlabHash<KeyT, ValueT, SlabHashT>(
+    slab_hash_ = new GpuSlabHash<KeyT, ValueT, SlabHashT, log_num_mem_blocks, num_super_blocks>(
         num_buckets_, dynamic_allocator_, device_idx_, seed_, identity_hash_);
     if (verbose) {
       std::cout << slab_hash_->to_string() << std::endl;

--- a/src/gpu_hash_table.cuh
+++ b/src/gpu_hash_table.cuh
@@ -50,16 +50,20 @@ class gpu_hash_table {
   ValueT* d_result_;
   uint32_t* d_count_;
 
+  float thresh_lf_;
+
   gpu_hash_table(uint32_t max_keys,
                  uint32_t num_buckets,
                  const uint32_t device_idx,
                  const int64_t seed,
                  const bool req_values = true,
                  const bool identity_hash = false,
-                 const bool verbose = false)
+                 const bool verbose = false,
+                 float thresh_lf = 0.60)
       : max_keys_(max_keys)
       , num_buckets_(num_buckets)
       , seed_(seed)
+      , thresh_lf_(thresh_lf)
       , req_values_(req_values)
       , slab_hash_(nullptr)
       , identity_hash_(identity_hash)
@@ -81,12 +85,11 @@ class gpu_hash_table {
     //CHECK_CUDA_ERROR(cudaMalloc((void**)&d_count_, sizeof(uint32_t) * max_keys_));
     
     // allocate an initialize the allocator:
-    //dynamic_allocator_ = new DynamicAllocatorT();
     dynamic_allocator_ = new SlabAllocLight<log_num_mem_blocks, num_super_blocks, 1>;
 
     // slab hash:
     slab_hash_ = new GpuSlabHash<KeyT, ValueT, SlabHashT, log_num_mem_blocks, num_super_blocks>(
-        num_buckets_, dynamic_allocator_, device_idx_, seed_, identity_hash_);
+        num_buckets_, dynamic_allocator_, device_idx_, seed_, identity_hash_, thresh_lf_);
     if (verbose) {
       std::cout << slab_hash_->to_string() << std::endl;
     }

--- a/src/gpu_hash_table.cuh
+++ b/src/gpu_hash_table.cuh
@@ -72,8 +72,8 @@ class gpu_hash_table {
     if (req_values_) {
       CHECK_CUDA_ERROR(cudaMalloc((void**)&d_value_, sizeof(ValueT) * max_keys_));
     }
-    //CHECK_CUDA_ERROR(cudaMalloc((void**)&d_query_, sizeof(KeyT) * max_keys_));
-    //CHECK_CUDA_ERROR(cudaMalloc((void**)&d_result_, sizeof(ValueT) * max_keys_));
+    CHECK_CUDA_ERROR(cudaMalloc((void**)&d_query_, sizeof(KeyT) * max_keys_));
+    CHECK_CUDA_ERROR(cudaMalloc((void**)&d_result_, sizeof(ValueT) * max_keys_));
     //CHECK_CUDA_ERROR(cudaMalloc((void**)&d_count_, sizeof(uint32_t) * max_keys_));
     
     // allocate an initialize the allocator:
@@ -93,8 +93,8 @@ class gpu_hash_table {
     if (req_values_) {
       CHECK_CUDA_ERROR(cudaFree(d_value_));
     }
-    //CHECK_CUDA_ERROR(cudaFree(d_query_));
-    //CHECK_CUDA_ERROR(cudaFree(d_result_));
+    CHECK_CUDA_ERROR(cudaFree(d_query_));
+    CHECK_CUDA_ERROR(cudaFree(d_result_));
     //CHECK_CUDA_ERROR(cudaFree(d_count_));
 
     // delete the dynamic allocator:

--- a/src/gpu_hash_table.cuh
+++ b/src/gpu_hash_table.cuh
@@ -72,10 +72,10 @@ class gpu_hash_table {
     if (req_values_) {
       CHECK_CUDA_ERROR(cudaMalloc((void**)&d_value_, sizeof(ValueT) * max_keys_));
     }
-    CHECK_CUDA_ERROR(cudaMalloc((void**)&d_query_, sizeof(KeyT) * max_keys_));
-    CHECK_CUDA_ERROR(cudaMalloc((void**)&d_result_, sizeof(ValueT) * max_keys_));
-    CHECK_CUDA_ERROR(cudaMalloc((void**)&d_count_, sizeof(uint32_t) * max_keys_));
-
+    //CHECK_CUDA_ERROR(cudaMalloc((void**)&d_query_, sizeof(KeyT) * max_keys_));
+    //CHECK_CUDA_ERROR(cudaMalloc((void**)&d_result_, sizeof(ValueT) * max_keys_));
+    //CHECK_CUDA_ERROR(cudaMalloc((void**)&d_count_, sizeof(uint32_t) * max_keys_));
+    
     // allocate an initialize the allocator:
     dynamic_allocator_ = new DynamicAllocatorT();
 
@@ -93,9 +93,9 @@ class gpu_hash_table {
     if (req_values_) {
       CHECK_CUDA_ERROR(cudaFree(d_value_));
     }
-    CHECK_CUDA_ERROR(cudaFree(d_query_));
-    CHECK_CUDA_ERROR(cudaFree(d_result_));
-    CHECK_CUDA_ERROR(cudaFree(d_count_));
+    //CHECK_CUDA_ERROR(cudaFree(d_query_));
+    //CHECK_CUDA_ERROR(cudaFree(d_result_));
+    //CHECK_CUDA_ERROR(cudaFree(d_count_));
 
     // delete the dynamic allocator:
     delete dynamic_allocator_;

--- a/src/gpu_hash_table.cuh
+++ b/src/gpu_hash_table.cuh
@@ -85,7 +85,7 @@ class gpu_hash_table {
     //CHECK_CUDA_ERROR(cudaMalloc((void**)&d_count_, sizeof(uint32_t) * max_keys_));
     
     // allocate an initialize the allocator:
-    dynamic_allocator_ = new SlabAllocLight<log_num_mem_blocks, num_super_blocks, 1>;
+    dynamic_allocator_ = new SlabAllocLight<log_num_mem_blocks, num_super_blocks, 1>(num_buckets);
 
     // slab hash:
     slab_hash_ = new GpuSlabHash<KeyT, ValueT, SlabHashT, log_num_mem_blocks, num_super_blocks>(

--- a/src/slab_hash_global.cuh
+++ b/src/slab_hash_global.cuh
@@ -127,7 +127,7 @@ class GpuSlabHashContext;
 // The custom allocator that is being used for this code:
 // this might need to be a template paramater itself
 namespace slab_alloc_par {
-constexpr uint32_t log_num_mem_blocks = 12;
+constexpr uint32_t log_num_mem_blocks = 11;
 constexpr uint32_t num_super_blocks = 2;
 constexpr uint32_t num_replicas = 1;
 }  // namespace slab_alloc_par

--- a/src/slab_hash_global.cuh
+++ b/src/slab_hash_global.cuh
@@ -129,7 +129,7 @@ class GpuSlabHashContext;
 // this might need to be a template paramater itself
 namespace slab_alloc_par {
 constexpr uint32_t log_num_mem_blocks = 9; // 64 MB 
-constexpr uint32_t num_super_blocks = 2;
+constexpr uint32_t num_super_blocks = 15;
 constexpr uint32_t num_replicas = 1;
 }  // namespace slab_alloc_par
 

--- a/src/slab_hash_global.cuh
+++ b/src/slab_hash_global.cuh
@@ -129,7 +129,7 @@ class GpuSlabHashContext;
 // this might need to be a template paramater itself
 namespace slab_alloc_par {
 constexpr uint32_t log_num_mem_blocks = 10; // 128 MB 
-constexpr uint32_t num_super_blocks = 5;
+constexpr uint32_t num_super_blocks = 1;
 constexpr uint32_t num_replicas = 1;
 }  // namespace slab_alloc_par
 

--- a/src/slab_hash_global.cuh
+++ b/src/slab_hash_global.cuh
@@ -119,10 +119,10 @@ class PhaseConcurrentMapT {
 };
 
 // the main class to be specialized for different types of hash tables
-template <typename KeyT, typename ValueT, SlabHashTypeT SlabHashT>
+template <typename KeyT, typename ValueT, SlabHashTypeT SlabHashT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
 class GpuSlabHash;
 
-template <typename KeyT, typename ValueT, SlabHashTypeT SlabHashT>
+template <typename KeyT, typename ValueT, SlabHashTypeT SlabHashT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
 class GpuSlabHashContext;
 
 // The custom allocator that is being used for this code:

--- a/src/slab_hash_global.cuh
+++ b/src/slab_hash_global.cuh
@@ -129,7 +129,7 @@ class GpuSlabHashContext;
 // this might need to be a template paramater itself
 namespace slab_alloc_par {
 constexpr uint32_t log_num_mem_blocks = 9; // 64 MB 
-constexpr uint32_t num_super_blocks = 11;
+constexpr uint32_t num_super_blocks = 2;
 constexpr uint32_t num_replicas = 1;
 }  // namespace slab_alloc_par
 

--- a/src/slab_hash_global.cuh
+++ b/src/slab_hash_global.cuh
@@ -127,8 +127,8 @@ class GpuSlabHashContext;
 // The custom allocator that is being used for this code:
 // this might need to be a template paramater itself
 namespace slab_alloc_par {
-constexpr uint32_t log_num_mem_blocks = 10; // 128 MB
-constexpr uint32_t num_super_blocks = 2;
+constexpr uint32_t log_num_mem_blocks = 10; // 128 MB 
+constexpr uint32_t num_super_blocks = 1;
 constexpr uint32_t num_replicas = 1;
 }  // namespace slab_alloc_par
 

--- a/src/slab_hash_global.cuh
+++ b/src/slab_hash_global.cuh
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "slab_alloc.cuh"
+#include "cub/cub.cuh"
 
 #define CHECK_CUDA_ERROR(call)                                                          \
   do {                                                                                  \

--- a/src/slab_hash_global.cuh
+++ b/src/slab_hash_global.cuh
@@ -129,7 +129,7 @@ class GpuSlabHashContext;
 // this might need to be a template paramater itself
 namespace slab_alloc_par {
 constexpr uint32_t log_num_mem_blocks = 9; // 64 MB 
-constexpr uint32_t num_super_blocks = 10;
+constexpr uint32_t num_super_blocks = 11;
 constexpr uint32_t num_replicas = 1;
 }  // namespace slab_alloc_par
 

--- a/src/slab_hash_global.cuh
+++ b/src/slab_hash_global.cuh
@@ -127,8 +127,8 @@ class GpuSlabHashContext;
 // The custom allocator that is being used for this code:
 // this might need to be a template paramater itself
 namespace slab_alloc_par {
-constexpr uint32_t log_num_mem_blocks = 8;
-constexpr uint32_t num_super_blocks = 32;
+constexpr uint32_t log_num_mem_blocks = 12;
+constexpr uint32_t num_super_blocks = 2;
 constexpr uint32_t num_replicas = 1;
 }  // namespace slab_alloc_par
 

--- a/src/slab_hash_global.cuh
+++ b/src/slab_hash_global.cuh
@@ -128,8 +128,8 @@ class GpuSlabHashContext;
 // The custom allocator that is being used for this code:
 // this might need to be a template paramater itself
 namespace slab_alloc_par {
-constexpr uint32_t log_num_mem_blocks = 10; // 128 MB 
-constexpr uint32_t num_super_blocks = 1;
+constexpr uint32_t log_num_mem_blocks = 9; // 64 MB 
+constexpr uint32_t num_super_blocks = 15;
 constexpr uint32_t num_replicas = 1;
 }  // namespace slab_alloc_par
 

--- a/src/slab_hash_global.cuh
+++ b/src/slab_hash_global.cuh
@@ -129,7 +129,7 @@ class GpuSlabHashContext;
 // this might need to be a template paramater itself
 namespace slab_alloc_par {
 constexpr uint32_t log_num_mem_blocks = 9; // 64 MB 
-constexpr uint32_t num_super_blocks = 15;
+constexpr uint32_t num_super_blocks = 10;
 constexpr uint32_t num_replicas = 1;
 }  // namespace slab_alloc_par
 

--- a/src/slab_hash_global.cuh
+++ b/src/slab_hash_global.cuh
@@ -129,7 +129,7 @@ class GpuSlabHashContext;
 // this might need to be a template paramater itself
 namespace slab_alloc_par {
 constexpr uint32_t log_num_mem_blocks = 10; // 128 MB 
-constexpr uint32_t num_super_blocks = 1;
+constexpr uint32_t num_super_blocks = 5;
 constexpr uint32_t num_replicas = 1;
 }  // namespace slab_alloc_par
 

--- a/src/slab_hash_global.cuh
+++ b/src/slab_hash_global.cuh
@@ -127,7 +127,7 @@ class GpuSlabHashContext;
 // The custom allocator that is being used for this code:
 // this might need to be a template paramater itself
 namespace slab_alloc_par {
-constexpr uint32_t log_num_mem_blocks = 11;
+constexpr uint32_t log_num_mem_blocks = 10; // 128 MB
 constexpr uint32_t num_super_blocks = 2;
 constexpr uint32_t num_replicas = 1;
 }  // namespace slab_alloc_par

--- a/src/slab_iterator.cuh
+++ b/src/slab_iterator.cuh
@@ -19,12 +19,12 @@
 // a forward iterator for the slab hash data structure:
 // currently just specialized for concurrent set
 // TODO implement for other types
-template <typename KeyT>
+template <typename KeyT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
 class SlabIterator {
  public:
   using SlabHashT = ConcurrentSetT<KeyT>;
 
-  GpuSlabHashContext<KeyT, KeyT, SlabHashTypeT::ConcurrentSet>& slab_hash_;
+  GpuSlabHashContext<KeyT, KeyT, SlabHashTypeT::ConcurrentSet, log_num_mem_blocks, num_super_blocks>& slab_hash_;
 
   // current position of the iterator
   KeyT* cur_ptr_;
@@ -35,7 +35,7 @@ class SlabIterator {
   // initialize the iterator with the first bucket's pointer address of the slab
   // hash
   __host__ __device__
-  SlabIterator(GpuSlabHashContext<KeyT, KeyT, SlabHashTypeT::ConcurrentSet>& slab_hash)
+  SlabIterator(GpuSlabHashContext<KeyT, KeyT, SlabHashTypeT::ConcurrentSet, log_num_mem_blocks, num_super_blocks>& slab_hash)
       : slab_hash_(slab_hash)
       , cur_ptr_(reinterpret_cast<KeyT*>(slab_hash_.getDeviceTablePointer()))
       , cur_size_(slab_hash_.getNumBuckets() * SlabHashT::BASE_UNIT_SIZE)

--- a/test/iterator_test.cu
+++ b/test/iterator_test.cu
@@ -28,9 +28,9 @@
 #define DEVICE_ID 0
 //=======================================
 
-template <typename KeyT>
+template <typename KeyT, uint32_t log_num_mem_blocks, uint32_t num_super_blocks>
 __global__ void print_table(
-    GpuSlabHashContext<KeyT, KeyT, SlabHashTypeT::ConcurrentSet> slab_hash) {
+    GpuSlabHashContext<KeyT, KeyT, SlabHashTypeT::ConcurrentSet, log_num_mem_blocks, num_super_blocks> slab_hash) {
   uint32_t tid = threadIdx.x + blockIdx.x * blockDim.x;
   uint32_t wid = tid >> 5;
   uint32_t laneId = threadIdx.x & 0x1F;
@@ -44,7 +44,7 @@ __global__ void print_table(
 
   if (tid == 0) {
     printf(" == Printing the base array\n");
-    SlabIterator<KeyT> iter(slab_hash);
+    SlabIterator<KeyT, log_num_mem_blocks, num_super_blocks> iter(slab_hash);
     for (int i = 0; i < iter.cur_size_; i++) {
       if ((i & 0x1F) == 0)
         printf(" == bucket %d:\n", i >> 5);


### PR DESCRIPTION
Modifications were made to SlabHash's `concurrent_map` as well as SlabAlloc to support dynamic growth of the device-side pool allocator used to extend slab lists. 

In the SlabHash implementation currently available on the `master` branch, the number of slabs in the device-side slab pool is fixed (to 1GB). Consequently, the total memory footprint of the slab hash is fixed during run time. The code in this PR allows the number of slabs in the pool to increase dynamically during run time. Specifically, `ConcurrentMap`'s `buildBulk` and `buildBulkWithUniqueKeys` determine whether the upcoming insertion batch will cause the structure to exceed a user-configurable threshold load factor. If so, new super blocks are added to the slab pool via `cudaMalloc` such that the structure's total memory footprint (sum of sizes of the base slabs and slab pool) doubles. Insertion then proceeds as normal. This allows the slab hash to continually grow its total memory footprint until device memory is exhausted. 

`gpu_hash_table` has 3 new parameters (with default values). First, there are two template parameters for the number of memory blocks and number of super blocks with which to initialize the SlabAlloc, allowing the user to configure the initial size of the slab pool. Next, there is a threshold load factor argument which allows the user to configure how much of the SlabHash's total memory footprint can be occupied by key-value pairs before the slab pool is grown to double the total memory footprint.